### PR TITLE
Add vault statistics endpoint and improve response structure

### DIFF
--- a/src/modules/vaults/dto/get-vaults-statistics.dto.ts
+++ b/src/modules/vaults/dto/get-vaults-statistics.dto.ts
@@ -31,11 +31,18 @@ export class VaultStatisticsResponse {
   totalValueAda: number;
 
   @ApiProperty({
-    description: 'Total number of contributed assets across all vaults',
+    description: 'Total number of contributed assets in usd across all vaults',
     example: 750,
   })
   @Expose()
-  totalContributed: number;
+  totalContributedUsd: number;
+
+  @ApiProperty({
+    description: 'Total number of contributed assets in ada across all vaults',
+    example: 1000,
+  })
+  @Expose()
+  totalContributedAda: number;
 
   @ApiProperty({
     description: 'Total number of assets ever contributed to any vault',

--- a/src/modules/vaults/dto/get-vaults-statistics.dto.ts
+++ b/src/modules/vaults/dto/get-vaults-statistics.dto.ts
@@ -1,0 +1,110 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class VaultStatisticsResponse {
+  @ApiProperty({
+    description: 'Number of active vaults (published, contribution, acquire, locked)',
+    example: 42,
+  })
+  @Expose()
+  activeVaults: number;
+
+  @ApiProperty({
+    description: 'Total number of vaults ever created',
+    example: 85,
+  })
+  @Expose()
+  totalVaults: number;
+
+  @ApiProperty({
+    description: 'Total value of locked vaults in USD',
+    example: 1250000,
+  })
+  @Expose()
+  totalValueUsd: number;
+
+  @ApiProperty({
+    description: 'Total value of locked vaults in ADA',
+    example: 3500000,
+  })
+  @Expose()
+  totalValueAda: number;
+
+  @ApiProperty({
+    description: 'Total number of contributed assets across all vaults',
+    example: 750,
+  })
+  @Expose()
+  totalContributed: number;
+
+  @ApiProperty({
+    description: 'Total number of assets ever contributed to any vault',
+    example: 1200,
+  })
+  @Expose()
+  totalAssets: number;
+
+  @ApiProperty({
+    description: 'Total ADA value ever acquired across all vaults',
+    example: 5000000,
+  })
+  @Expose()
+  totalAcquiredAda: number;
+
+  @ApiProperty({
+    description: 'Total USD value ever acquired across all vaults',
+    example: 1750000,
+  })
+  @Expose()
+  totalAcquiredUsd: number;
+
+  @ApiProperty({
+    description: 'Distribution of vaults by stage (draft, contribution, acquire, locked, terminated)',
+    example: {
+      draft: {
+        percentage: 10,
+        valueAda: 2500000,
+        valueUsd: 875000,
+      },
+    },
+  })
+  @Expose()
+  vaultsByStage: Record<
+    string,
+    {
+      percentage: number;
+      valueAda: number;
+      valueUsd: number;
+    }
+  >;
+
+  @ApiProperty({
+    description: 'Distribution of vaults by privacy type (private, semi-private, public)',
+    example: {
+      private: {
+        percentage: 30.33,
+        valueAda: 7582500,
+        valueUsd: 2653875,
+      },
+      semiPrivate: {
+        percentage: 26,
+        valueAda: 6500000,
+        valueUsd: 2275000,
+      },
+      public: {
+        percentage: 43.67,
+        valueAda: 10917500,
+        valueUsd: 3821125,
+      },
+    },
+  })
+  @Expose()
+  vaultsByType: Record<
+    string,
+    {
+      percentage: number;
+      valueAda: number;
+      valueUsd: number;
+    }
+  >;
+}

--- a/src/modules/vaults/dto/vault.response.ts
+++ b/src/modules/vaults/dto/vault.response.ts
@@ -41,12 +41,25 @@ export class VaultShortResponse {
   })
   description?: string;
 
-  @ApiProperty({ description: 'Tvl', required: true })
+  @ApiProperty({
+    description: 'Total value of locked vaults in USD',
+    example: 1250000,
+  })
   @DtoRepresent({
-    transform: ({ value }) => (value ? Number(value) : null),
+    transform: false,
     expose: true,
   })
-  tvl: number;
+  totalValueUsd: number;
+
+  @ApiProperty({
+    description: 'Total value of locked vaults in ADA',
+    example: 3500000,
+  })
+  @DtoRepresent({
+    transform: false,
+    expose: true,
+  })
+  totalValueAda: number;
 
   @ApiProperty({ description: 'Tvl', required: true })
   @DtoRepresent({

--- a/src/modules/vaults/vaults.controller.ts
+++ b/src/modules/vaults/vaults.controller.ts
@@ -107,7 +107,7 @@ export class VaultsController {
 
   @ApiDoc({
     summary: 'Get vault statistics for landing page',
-    description: 'Returns statxistics about active vaults, total value in USD and ADA, and total contributed assets',
+    description: 'Returns statistics about active vaults, total value in USD and ADA, and total contributed assets',
     status: 200,
   })
   @Get('statistics')

--- a/src/modules/vaults/vaults.controller.ts
+++ b/src/modules/vaults/vaults.controller.ts
@@ -7,6 +7,7 @@ import { AuthGuard } from '../auth/auth.guard';
 import { DraftVaultsService } from './draft-vaults.service';
 import { CreateVaultReq } from './dto/createVault.req';
 import { GetVaultTransactionsDto } from './dto/get-vault-transactions.dto';
+import { VaultStatisticsResponse } from './dto/get-vaults-statistics.dto';
 import { GetVaultsDto } from './dto/get-vaults.dto';
 import { PaginatedResponseDto } from './dto/paginated-response.dto';
 import { PublishVaultDto } from './dto/publish-vault.dto';
@@ -38,7 +39,10 @@ export class VaultsController {
     @Request() req,
     @Body()
     data: CreateVaultReq
-  ) {
+  ): Promise<{
+    vaultId: string;
+    presignedTx: string;
+  }> {
     const userId = req.user.sub;
     return this.vaultsService.createVault(userId, data);
   }
@@ -99,6 +103,16 @@ export class VaultsController {
   @Get('acquire')
   async getAcquire(): Promise<VaultAcquireResponse[]> {
     return this.vaultsService.getAcquire();
+  }
+
+  @ApiDoc({
+    summary: 'Get vault statistics for landing page',
+    description: 'Returns statxistics about active vaults, total value in USD and ADA, and total contributed assets',
+    status: 200,
+  })
+  @Get('statistics')
+  async getVaultStatistics(): Promise<VaultStatisticsResponse> {
+    return await this.vaultsService.getVaultStatistics();
   }
 
   @ApiDoc({

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -1,15 +1,22 @@
 import { Credential, EnterpriseAddress, ScriptHash } from '@emurgo/cardano-serialization-lib-nodejs';
-import { BadRequestException, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { instanceToPlain, plainToInstance } from 'class-transformer';
 import * as csv from 'csv-parse';
-import { Brackets, Repository } from 'typeorm';
+import { Brackets, In, Repository } from 'typeorm';
 
 import { AwsService } from '../aws_bucket/aws.service';
 import { TaptoolsService } from '../taptools/taptools.service';
 
 import { CreateVaultReq } from './dto/createVault.req';
+import { VaultStatisticsResponse } from './dto/get-vaults-statistics.dto';
 import { DateRangeDto, SortOrder, TVLCurrency, VaultFilter, VaultSortField } from './dto/get-vaults.dto';
 import { PaginatedResponseDto } from './dto/paginated-response.dto';
 import { PublishVaultDto } from './dto/publish-vault.dto';
@@ -381,6 +388,19 @@ export class VaultsService {
       // Handle assets whitelist
       // TODO: Add lovelace support
       let maxCountOf = 0;
+      const uniquePolicyIds = new Set();
+
+      // First, validate for duplicate policy IDs
+      for (const assetItem of data.assetsWhitelist) {
+        if (assetItem.policyId) {
+          if (uniquePolicyIds.has(assetItem.policyId)) {
+            throw new BadRequestException(`Duplicate policy ID in assets whitelist: ${assetItem.policyId}`);
+          }
+          uniquePolicyIds.add(assetItem.policyId);
+        }
+      }
+
+      // Then process them
       await Promise.all(
         data.assetsWhitelist.map(assetItem => {
           if (assetItem.policyId) {
@@ -584,6 +604,185 @@ export class VaultsService {
       }
 
       throw new BadRequestException('Failed to create vault. Please check your input and try again.');
+    }
+  }
+
+  /**
+   * Retrieves statistics about vaults for the landing page.
+   *
+   * @returns Object containing platform statistics
+   */
+  async getVaultStatistics(): Promise<VaultStatisticsResponse> {
+    try {
+      // Count active vaults (published, contribution, acquire, locked)
+      const activeVaultsCount = await this.vaultsRepository.count({
+        where: {
+          vault_status: In([VaultStatus.contribution, VaultStatus.acquire, VaultStatus.locked]),
+          deleted: false,
+        },
+      });
+
+      const totalVaultsCount = await this.vaultsRepository.count({
+        where: {
+          vault_status: In([VaultStatus.published, VaultStatus.contribution, VaultStatus.acquire, VaultStatus.locked]),
+        },
+      });
+      // Get sum of total assets value for locked vaults only
+      const totalValueQuery = await this.vaultsRepository
+        .createQueryBuilder('vault')
+        .select('SUM(vault.total_assets_cost_usd)', 'totalValueUsd')
+        .addSelect('SUM(vault.total_assets_cost_ada)', 'totalValueAda')
+        .where('vault.vault_status = :status', { status: VaultStatus.locked })
+        .andWhere('vault.deleted = :deleted', { deleted: false })
+        .getRawOne();
+
+      // Count total assets contributed across all vaults
+      const totalContributedQuery = await this.assetsRepository
+        .createQueryBuilder('asset')
+        .select('COUNT(asset.id)', 'count')
+        .where('asset.origin_type = :originType', { originType: AssetOriginType.CONTRIBUTED })
+        .getRawOne();
+
+      // Count total assets ever contributed (all time, including removed)
+      const totalAssetsQuery = await this.assetsRepository
+        .createQueryBuilder('asset')
+        .select('COUNT(asset.id)', 'count')
+        .getRawOne();
+
+      // Get total acquired value (both ADA and USD) across all vaults
+      const totalAcquiredQuery = await this.vaultsRepository
+        .createQueryBuilder('vault')
+        .select('SUM(vault.total_acquired_value_ada)', 'totalAcquiredAda')
+        .getRawOne();
+
+      const vaultsByStage = await this.getVaultsByStageData();
+      const vaultsByType = await this.getVaultsByTypeData();
+
+      const adaPrice = await this.taptoolsService.getAdaPrice();
+
+      const statistics = {
+        activeVaults: activeVaultsCount,
+        totalVaults: totalVaultsCount,
+        totalValueUsd: Number(totalValueQuery?.totalValueUsd || 0),
+        totalValueAda: Number(totalValueQuery?.totalValueAda || 0),
+        totalContributed: Number(totalContributedQuery?.count || 0),
+        totalAssets: Number(totalAssetsQuery?.count || 0),
+        totalAcquiredAda: Number(totalAcquiredQuery?.totalAcquiredAda || 0),
+        totalAcquiredUsd: parseFloat((Number(totalAcquiredQuery?.totalAcquiredAda || 0) * adaPrice).toFixed(2)),
+        vaultsByStage,
+        vaultsByType,
+      };
+
+      return plainToInstance(VaultStatisticsResponse, statistics, {
+        excludeExtraneousValues: true,
+      });
+    } catch (error) {
+      this.logger.error('Error retrieving vault statistics:', error);
+      throw new InternalServerErrorException('Failed to retrieve vault statistics');
+    }
+  }
+
+  /**
+   * Gets distribution of vaults by stage with TVL in both ADA and USD
+   * @returns Record of stages with percentages and TVL values
+   */
+  private async getVaultsByStageData(): Promise<
+    Record<string, { percentage: number; valueAda: string; valueUsd: string }>
+  > {
+    try {
+      // Get TVL by vault status for both currencies
+      const statusResults = await this.vaultsRepository
+        .createQueryBuilder('vault')
+        .select('vault.vault_status', 'status')
+        .addSelect('SUM(vault.total_assets_cost_ada)', 'valueAda')
+        .addSelect('SUM(vault.total_assets_cost_usd)', 'valueUsd')
+        .addSelect('COUNT(vault.id)', 'count')
+        .where('vault.deleted = :deleted', { deleted: false })
+        .groupBy('vault.vault_status')
+        .getRawMany();
+
+      // Calculate total ADA value for percentages
+      const totalValueAda = statusResults.reduce((sum, item) => sum + Number(item.valueAda || 0), 0);
+
+      const result = {};
+
+      // Map status values to friendly names
+      const statusMap = {
+        draft: 'Draft',
+        created: 'Created',
+        published: 'Published',
+        contribution: 'Contribution',
+        acquire: 'Acquire',
+        locked: 'Locked',
+        terminated: 'Terminated',
+      };
+
+      // Process each status
+      statusResults.forEach(item => {
+        const status = statusMap[item.status] || item.status;
+        const valueAda = Number(item.valueAda || 0);
+        const valueUsd = Number(item.valueUsd || 0);
+        const percentage = totalValueAda > 0 ? (valueAda / totalValueAda) * 100 : 0;
+
+        result[status.toLowerCase()] = {
+          percentage: parseFloat(percentage.toFixed(2)),
+          valueAda,
+          valueUsd,
+        };
+      });
+
+      return result;
+    } catch (error) {
+      this.logger.error('Error calculating vaults by stage:', error);
+      return {};
+    }
+  }
+
+  /**
+   * Gets distribution of vaults by privacy type with TVL in both ADA and USD
+   * @returns Record of privacy types with percentages and TVL values
+   */
+  private async getVaultsByTypeData(): Promise<
+    Record<string, { percentage: number; valueAda: string; valueUsd: string }>
+  > {
+    try {
+      // Get TVL by privacy type for both currencies
+      const privacyResults = await this.vaultsRepository
+        .createQueryBuilder('vault')
+        .select('vault.privacy', 'type')
+        .addSelect('SUM(vault.total_assets_cost_ada)', 'valueAda')
+        .addSelect('SUM(vault.total_assets_cost_usd)', 'valueUsd')
+        .addSelect('COUNT(vault.id)', 'count')
+        .where('vault.deleted = :deleted', { deleted: false })
+        .groupBy('vault.privacy')
+        .getRawMany();
+
+      // Calculate total ADA value for percentages
+      const totalValueAda = privacyResults.reduce((sum, item) => sum + Number(item.valueAda || 0), 0);
+
+      const result = {};
+
+      // Process each privacy type
+      privacyResults.forEach(item => {
+        if (item.type) {
+          const type = item.type;
+          const valueAda = Number(item.valueAda || 0);
+          const valueUsd = Number(item.valueUsd || 0);
+          const percentage = parseFloat((totalValueAda > 0 ? (valueAda / totalValueAda) * 100 : 0).toFixed(2)) || 0;
+
+          const key = type === 'Semi-Private' ? 'semiPrivate' : type.toLowerCase();
+          result[key] = {
+            percentage,
+            valueAda,
+            valueUsd,
+          };
+        }
+      });
+
+      return result;
+    } catch (error) {
+      this.logger.error('Error calculating vaults by type:', error);
+      return {};
     }
   }
 

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -32,6 +32,7 @@ import { AssetsWhitelistEntity } from '@/database/assetsWhitelist.entity';
 import { ContributorWhitelistEntity } from '@/database/contributorWhitelist.entity';
 import { FileEntity } from '@/database/file.entity';
 import { LinkEntity } from '@/database/link.entity';
+import { AddTotalAcquiredValueInAda1750670509513 } from '@/database/migrations/1750670509513-addTotalAcquiredValueInAda';
 import { TagEntity } from '@/database/tag.entity';
 import { User } from '@/database/user.entity';
 import { Vault } from '@/database/vault.entity';
@@ -1214,7 +1215,8 @@ export class VaultsService {
         // Merge calculated values with plain object
         const enrichedVault = {
           ...plainVault,
-          tvl: vault.total_assets_cost_usd,
+          totalValueUsd: vault.total_assets_cost_usd,
+          totalValueAda: vault.total_assets_cost_ada,
           baseAllocation: null,
           total: null,
           invested: vault.total_acquired_value_ada,


### PR DESCRIPTION
Introduce a new endpoint for retrieving vault statistics, enhance the response DTO to provide clearer asset contributions by currency, and ensure consistent data types across responses. Fix minor issues for clarity and consistency.