### PR TITLE
UPDATED: saveDraft dto

### DIFF
--- a/src/modules/vaults/draft-vaults.service.ts
+++ b/src/modules/vaults/draft-vaults.service.ts
@@ -327,8 +327,8 @@ export class DraftVaultsService {
       }
 
       // Handle contributor whitelist only if provided and vault is private
-      if (data.whitelistContributors !== undefined && data.whitelistContributors.length > 0) {
-        const contributorItems = data.whitelistContributors.map(item => {
+      if (data.contributorWhitelist !== undefined && data.contributorWhitelist.length > 0) {
+        const contributorItems = data.contributorWhitelist.map(item => {
           return this.contributorWhitelistRepository.create({
             vault: vault,
             wallet_address: item.policyId,

--- a/src/modules/vaults/dto/saveDraft.req.ts
+++ b/src/modules/vaults/dto/saveDraft.req.ts
@@ -377,7 +377,7 @@ export class SaveDraftReq {
   @IsArray()
   @Type(() => ContributorWhitelist)
   @Expose()
-  whitelistContributors?: ContributorWhitelist[] | null;
+  contributorWhitelist?: ContributorWhitelist[] | null;
 
   @ApiProperty({ required: false, nullable: true, type: [SocialLink] })
   @IsOptional()


### PR DESCRIPTION
Fixed problem when a Private Vault is launched directly from a draft, the Contributor Whitelist field is not displayed in the vault creation or launch interface, preventing proper configuration.