### PR TITLE
FIXED: migrations

### DIFF
--- a/src/database/migrations/1775479734547-FixVaultTagsFKCascade.ts
+++ b/src/database/migrations/1775479734547-FixVaultTagsFKCascade.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixVaultTagsFKCascade1775479734547 implements MigrationInterface {
+  name = 'FixVaultTagsFKCascade1775479734547';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "vault_tags" DROP CONSTRAINT "FK_adf9f0b047319be1ec67ac1d1eb"`);
+    await queryRunner.query(`ALTER TABLE "vault_tags" DROP CONSTRAINT "FK_2b3fd4667b2be7a2d7a329083cc"`);
+    await queryRunner.query(
+      `ALTER TABLE "vault_tags" ADD CONSTRAINT "FK_adf9f0b047319be1ec67ac1d1eb" FOREIGN KEY ("vault_id") REFERENCES "vaults"("id") ON DELETE CASCADE ON UPDATE CASCADE`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "vault_tags" ADD CONSTRAINT "FK_2b3fd4667b2be7a2d7a329083cc" FOREIGN KEY ("tag_id") REFERENCES "tags"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "vault_tags" DROP CONSTRAINT "FK_2b3fd4667b2be7a2d7a329083cc"`);
+    await queryRunner.query(`ALTER TABLE "vault_tags" DROP CONSTRAINT "FK_adf9f0b047319be1ec67ac1d1eb"`);
+    await queryRunner.query(
+      `ALTER TABLE "vault_tags" ADD CONSTRAINT "FK_2b3fd4667b2be7a2d7a329083cc" FOREIGN KEY ("tag_id") REFERENCES "tags"("id") ON DELETE CASCADE ON UPDATE CASCADE`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "vault_tags" ADD CONSTRAINT "FK_adf9f0b047319be1ec67ac1d1eb" FOREIGN KEY ("vault_id") REFERENCES "vaults"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+}

--- a/src/database/tag.entity.ts
+++ b/src/database/tag.entity.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany } from 'typeorm';
 
 import { Vault } from './vault.entity';
 
@@ -13,16 +13,5 @@ export class TagEntity {
 
   @Expose({ name: 'vaults' })
   @ManyToMany(() => Vault, (vault: Vault) => vault.tags)
-  @JoinTable({
-    name: 'vault_tags',
-    joinColumn: {
-      name: 'tag_id',
-      referencedColumnName: 'id',
-    },
-    inverseJoinColumn: {
-      name: 'vault_id',
-      referencedColumnName: 'id',
-    },
-  })
   vaults: Vault[];
 }

--- a/src/database/vault.entity.ts
+++ b/src/database/vault.entity.ts
@@ -528,7 +528,6 @@ export class Vault {
     name: 'acquire_multiplier',
     type: 'jsonb',
     nullable: true,
-    default: () => 'null',
   })
   acquire_multiplier?: Array<[string, string | null, number]>; // [policyId, assetName?, multiplier]
 
@@ -537,7 +536,6 @@ export class Vault {
     name: 'ada_distribution',
     type: 'jsonb',
     nullable: true,
-    default: () => 'null',
   })
   ada_distribution?: Array<[string, string, number]>; // [policyId, assetName, ada]
 
@@ -609,7 +607,6 @@ export class Vault {
     name: 'apply_params_result',
     type: 'jsonb',
     nullable: true,
-    default: () => 'null',
   })
   apply_params_result?: ApplyParamsResult;
 
@@ -643,7 +640,6 @@ export class Vault {
     name: 'dispatch_preloaded_script',
     type: 'jsonb',
     nullable: true,
-    default: () => 'null',
   })
   dispatch_preloaded_script?: ApplyParamsResult;
 


### PR DESCRIPTION
This pull request updates the database schema and entity relationships for vaults and tags. The main focus is on correcting the foreign key constraints in the `vault_tags` join table to ensure proper cascading behavior, and simplifying the entity definitions by removing redundant decorators and default values for JSONB columns.

**Database schema and relationship changes:**

* Updated the `vault_tags` join table to set the foreign key from `vault_id` to `vaults.id` with `ON DELETE CASCADE ON UPDATE CASCADE`, ensuring that deleting a vault will also remove its associated tags. The foreign key from `tag_id` to `tags.id` remains with no cascading actions.
* Removed the `@JoinTable` decorator from the `vaults` property in `TagEntity`, as the join table configuration is now handled solely on the `Vault` side.
* Cleaned up imports in `tag.entity.ts` by removing the unused `@JoinTable` import.

**Entity property simplification:**

* Removed unnecessary `default: () => 'null'` from several nullable `jsonb` columns (`acquire_multiplier`, `ada_distribution`, `apply_params_result`, `dispatch_preloaded_script`) in the `Vault` entity, relying on the database's handling of nulls for these fields. [[1]](diffhunk://#diff-7cf633a4566d71fbb8aca846021ccc3ac2dfd1d54a5eff910f4cecfdcc953e56L531) [[2]](diffhunk://#diff-7cf633a4566d71fbb8aca846021ccc3ac2dfd1d54a5eff910f4cecfdcc953e56L540) [[3]](diffhunk://#diff-7cf633a4566d71fbb8aca846021ccc3ac2dfd1d54a5eff910f4cecfdcc953e56L612) [[4]](diffhunk://#diff-7cf633a4566d71fbb8aca846021ccc3ac2dfd1d54a5eff910f4cecfdcc953e56L646)