### PR TITLE
Include VaultStatus.expansion in open vault filter query

### DIFF
--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -1294,7 +1294,7 @@ export class VaultsService {
       switch (filter) {
         case VaultFilter.open:
           queryBuilder.andWhere('vault.vault_status IN (:...statuses)', {
-            statuses: [VaultStatus.published, VaultStatus.contribution, VaultStatus.acquire],
+            statuses: [VaultStatus.published, VaultStatus.contribution, VaultStatus.acquire, VaultStatus.expansion],
           });
           break;
         case VaultFilter.contribution:


### PR DESCRIPTION
This pull request makes a small update to the `VaultsService` to include an additional vault status in the filtering logic. Specifically, it expands the set of statuses considered "open" to also include the `expansion` status.

- Added `VaultStatus.expansion` to the list of statuses included in the "open" filter for vaults in `vaults.service.ts`.