### PR TITLE
FIXED: collection name record for whitelist

### DIFF
--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -260,6 +260,7 @@ export class VaultsService {
       const uniqueWhitelistItems = Array.from(
         new Map((data.assetsWhitelist || []).map(item => [`${item.policyId}:${item.assetName || ''}`, item])).values()
       );
+      const collectionNameByPolicyId = new Map<string, string>();
       if (uniqueWhitelistItems.length > 0) {
         const whitelistCollections = await this.getCollections(
           uniqueWhitelistItems.map(item => ({
@@ -276,6 +277,14 @@ export class VaultsService {
           throw new BadRequestException(
             `All whitelist tokens must be verified. Unverified policy IDs: ${unverifiedPolicies.join(', ')}`
           );
+        }
+
+        // Build a fallback map for collection names. This prevents saving null collection_name
+        // when the client doesn't send collectionName but verification lookup knows it.
+        for (const c of whitelistCollections) {
+          if (c?.policy_id && c.collection_name) {
+            collectionNameByPolicyId.set(c.policy_id, c.collection_name);
+          }
         }
       }
 
@@ -390,13 +399,22 @@ export class VaultsService {
         uniquePolicyIds.map(async assetItem => {
           if (!assetItem.policyId) return;
 
+          const rawFallbackCollectionName =
+            assetItem.collectionName ||
+            collectionNameByPolicyId.get(assetItem.policyId) ||
+            assetItem.name ||
+            assetItem.policyName ||
+            null;
+
+          const fallbackCollectionName = rawFallbackCollectionName ? rawFallbackCollectionName.slice(0, 255) : null;
+
           const result = await this.assetsWhitelistRepository
             .createQueryBuilder()
             .insert()
             .values({
               vault: newVault,
               policy_id: assetItem.policyId,
-              collection_name: assetItem.collectionName,
+              collection_name: fallbackCollectionName,
               asset_count_cap_min: assetItem.countCapMin,
               asset_count_cap_max: assetItem.countCapMax,
               valuation_method: assetItem.valuationMethod || 'market',


### PR DESCRIPTION
This pull request improves how collection names are handled when saving whitelist assets in the `VaultsService`. The main change ensures that a valid collection name is always saved, even if the client does not provide one, by using verified collection data as a fallback.

**Collection name handling improvements:**

* Added a `collectionNameByPolicyId` map to store verified collection names by `policy_id` after fetching whitelist collections. This prevents saving a `null` collection name when the client omits it but verification data is available. [[1]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R263) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R281-R288)
* Updated the asset insertion logic to use a prioritized fallback for `collection_name`: it now tries the asset's provided `collectionName`, then the verified collection name from the map, then falls back to the asset's `name`, then `policyName`, and finally `null` if none are available.