### PR TITLE
Fix collection name record for whitelist

### DIFF
--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -260,6 +260,7 @@ export class VaultsService {
       const uniqueWhitelistItems = Array.from(
         new Map((data.assetsWhitelist || []).map(item => [`${item.policyId}:${item.assetName || ''}`, item])).values()
       );
+      const collectionNameByPolicyId = new Map<string, string>();
       if (uniqueWhitelistItems.length > 0) {
         const whitelistCollections = await this.getCollections(
           uniqueWhitelistItems.map(item => ({
@@ -276,6 +277,14 @@ export class VaultsService {
           throw new BadRequestException(
             `All whitelist tokens must be verified. Unverified policy IDs: ${unverifiedPolicies.join(', ')}`
           );
+        }
+
+        // Build a fallback map for collection names. This prevents saving null collection_name
+        // when the client doesn't send collectionName but verification lookup knows it.
+        for (const c of whitelistCollections) {
+          if (c?.policy_id && c.collection_name) {
+            collectionNameByPolicyId.set(c.policy_id, c.collection_name);
+          }
         }
       }
 
@@ -390,13 +399,22 @@ export class VaultsService {
         uniquePolicyIds.map(async assetItem => {
           if (!assetItem.policyId) return;
 
+          const rawFallbackCollectionName =
+            assetItem.collectionName ||
+            collectionNameByPolicyId.get(assetItem.policyId) ||
+            assetItem.name ||
+            assetItem.policyName ||
+            null;
+
+          const fallbackCollectionName = rawFallbackCollectionName ? rawFallbackCollectionName.slice(0, 255) : null;
+
           const result = await this.assetsWhitelistRepository
             .createQueryBuilder()
             .insert()
             .values({
               vault: newVault,
               policy_id: assetItem.policyId,
-              collection_name: assetItem.collectionName,
+              collection_name: fallbackCollectionName,
               asset_count_cap_min: assetItem.countCapMin,
               asset_count_cap_max: assetItem.countCapMax,
               valuation_method: assetItem.valuationMethod || 'market',


### PR DESCRIPTION
This pull request improves the way collection names are determined and stored for whitelist assets in the `VaultsService`. The main enhancement is a fallback mechanism that ensures a valid collection name is always saved, even if the client omits it but it can be inferred from verification data. This prevents `null` values for `collection_name` and increases data consistency.

**Improvements to collection name handling:**

* Introduced a `collectionNameByPolicyId` map to store collection names retrieved during the whitelist verification process, allowing for fallback lookup when the client does not provide a collection name. [[1]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R263) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R281-R288)
* Updated the asset whitelist insertion logic to use a prioritized fallback for `collection_name`: it now tries the client-provided value, then the verified collection name, then asset or policy names, and finally falls back to `null` (truncated to 255 characters if necessary).