### PR TITLE
Fix asset_id assignment in VLRM fee asset creation

### DIFF
--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -148,6 +148,7 @@ export class AssetsService {
         origin_type: AssetOriginType.FEE,
         decimals: 4, // VLRM has 4 decimal places
         name: 'VLRM',
+        description: 'The governance and utility token of the Relics of Magma.',
         last_valuation: new Date(),
         added_by: { id: ownerId },
         image: 'ipfs://QmdYu513Bu7nfKV5LKP6cmpZ8HHXifQLH6FTTzv3VbbqwP', // VLRM logo

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -140,7 +140,7 @@ export class AssetsService {
       const vlrmAsset = this.assetsRepository.create({
         vault_id: vault.id,
         policy_id: this.VLRM_POLICY_ID,
-        asset_id: `${this.VLRM_POLICY_ID}${this.VLRM_HEX_ASSET_NAME}`,
+        asset_id: this.VLRM_HEX_ASSET_NAME,
         type: AssetType.FT,
         dex_price: vlrmDexPrice,
         quantity: this.systemSettingsService.vlrmCreatorFee,

--- a/src/modules/vaults/market-stats/vault-market-stats.service.ts
+++ b/src/modules/vaults/market-stats/vault-market-stats.service.ts
@@ -176,11 +176,7 @@ export class VaultMarketStatsService {
           // This data is essential and stored in market.totalAdaLiquidity
           const liquidityCheck = await this.dexHunterPricingService.checkTokenLiquidity(unit);
 
-          if (liquidityCheck?.hasLiquidity) {
-            this.logger.log(
-              `${vault.name}: DexHunter detected liquidity (${liquidityCheck.totalAdaLiquidity.toFixed(2)} ADA across ${liquidityCheck.pools.length} pool(s))`
-            );
-          } else {
+          if (!liquidityCheck?.hasLiquidity) {
             this.logger.debug(`${vault.name}: No liquidity detected by DexHunter, skipping Taptools API`);
 
             // Update LP status to false and record check time


### PR DESCRIPTION
This pull request makes targeted improvements to the handling and logging of vault assets and market stats. The main changes are focused on correcting asset creation logic and refining liquidity logging for clarity and accuracy.

**Vault asset creation improvements:**

* In `assets.service.ts`, the `asset_id` for VLRM assets is now set to `this.VLRM_HEX_ASSET_NAME` (removing the policy prefix), and a descriptive string has been added to the asset's `description` field for clarity.

**Market stats logging refinement:**

* In `vault-market-stats.service.ts`, the logging logic for DEX liquidity checks has been simplified: only the absence of liquidity is now logged (as a debug message), reducing unnecessary log noise when liquidity is present.