### PR TITLE
Fix asset images array and save collection name for drafts

### DIFF
--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -1785,9 +1785,12 @@ export class TaptoolsService {
         (details.onchain_metadata as Record<string, unknown>)?.image,
         (details.onchain_metadata as Record<string, unknown>)?.logo,
       ];
-      const rawImage = rawImageCandidates.find((candidate): candidate is string => typeof candidate === 'string') || '';
+      const rawImage =
+        rawImageCandidates.find(
+          (candidate): candidate is string | string[] => typeof candidate === 'string' || Array.isArray(candidate)
+        ) || '';
 
-      // Normalize image source (handles base64, IPFS, HTTP, etc.)
+      // Normalize image source (handles base64, IPFS, HTTP, chunked array, etc.)
       let normalizedImage = normalizeAssetImageSource(rawImage) || '';
 
       if (/^ipfs:\/\//i.test(normalizedImage)) {

--- a/src/modules/vaults/draft-vaults.service.ts
+++ b/src/modules/vaults/draft-vaults.service.ts
@@ -302,7 +302,10 @@ export class DraftVaultsService {
             return this.assetsWhitelistRepository.save({
               vault: vault,
               policy_id: whitelistItem.policyId,
-              collection_name: whitelistItem.collectionName,
+              collection_name:
+                typeof whitelistItem.collectionName === 'string'
+                  ? whitelistItem.collectionName.slice(0, 255)
+                  : whitelistItem.collectionName,
               asset_count_cap_min: whitelistItem?.countCapMin,
               asset_count_cap_max: whitelistItem?.countCapMax,
               valuation_method: whitelistItem?.valuationMethod || 'market',

--- a/src/modules/vaults/draft-vaults.service.ts
+++ b/src/modules/vaults/draft-vaults.service.ts
@@ -302,6 +302,7 @@ export class DraftVaultsService {
             return this.assetsWhitelistRepository.save({
               vault: vault,
               policy_id: whitelistItem.policyId,
+              collection_name: whitelistItem.collectionName,
               asset_count_cap_min: whitelistItem?.countCapMin,
               asset_count_cap_max: whitelistItem?.countCapMax,
               valuation_method: whitelistItem?.valuationMethod || 'market',

--- a/src/modules/vaults/processing-tx/offchain-tx/transactions.service.ts
+++ b/src/modules/vaults/processing-tx/offchain-tx/transactions.service.ts
@@ -177,7 +177,8 @@ export class TransactionsService {
           (blockfrostMetadata?.metadata as any)?.logo ||
           null;
 
-        const cleanImage = typeof rawImage === 'string' ? normalizeAssetImageSource(rawImage) : null;
+        const cleanImage =
+          typeof rawImage === 'string' || Array.isArray(rawImage) ? normalizeAssetImageSource(rawImage) : null;
 
         const finalDescription =
           assetItem.description ||

--- a/src/utils/asset-image-source.util.ts
+++ b/src/utils/asset-image-source.util.ts
@@ -1,6 +1,12 @@
 /** Normalizes Cardano asset image/logo field into URL or data URL usable by image pipeline. */
-export function normalizeAssetImageSource(raw: string | null | undefined): string | null {
+export function normalizeAssetImageSource(raw: string | string[] | null | undefined): string | null {
   const MAX_HEX_METADATA_CHARS = 64 * 1024; // 64KB hex text (~32KB decoded bytes)
+
+  // Cardano on-chain metadata often splits long strings into arrays of ≤64-char chunks.
+  if (Array.isArray(raw)) {
+    const joined = raw.map(chunk => (typeof chunk === 'string' ? chunk : '')).join('');
+    return normalizeAssetImageSource(joined);
+  }
 
   if (raw == null || typeof raw !== 'string') {
     return null;


### PR DESCRIPTION
This pull request improves how asset images are handled throughout the codebase, particularly by supporting chunked array formats often found in Cardano on-chain metadata. The main changes ensure that image fields represented as arrays of string chunks are correctly normalized and processed, preventing issues with image display and metadata handling.

**Asset image normalization and processing:**

* Updated `normalizeAssetImageSource` in `asset-image-source.util.ts` to accept `string[]` in addition to `string`, and to join arrays of string chunks before normalization. This handles Cardano metadata where long image strings are split into arrays.
* Updated logic in `TaptoolsService` and `TransactionsService` to detect and properly handle image/logo fields that may be arrays, ensuring they are passed to the normalization utility. [[1]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L1788-R1793) [[2]](diffhunk://#diff-1b9f814adb7defc4eb1bec1f39495152149b731c6c77060e2a0221e47f962a2cL180-R181)

**Vault asset whitelist improvements:**

* Truncated `collectionName` to 255 characters if it's a string when saving to the assets whitelist in `DraftVaultsService`, preventing overly long values from causing database issues.