### PR TITLE
FIXED: liquidity check for market vaults

### DIFF
--- a/src/modules/market/market.service.ts
+++ b/src/modules/market/market.service.ts
@@ -120,6 +120,8 @@ export class MarketService implements OnModuleInit {
   }
 
   private applyVisibilityFilters(queryBuilder: SelectQueryBuilder<Market>): void {
+    queryBuilder.andWhere('vault.has_active_lp = true');
+
     if (this.isMainnet) {
       const hiddenIds = this.systemSettingsService.hiddenMainnetVaultIds;
       if (hiddenIds.length > 0) {
@@ -218,6 +220,7 @@ export class MarketService implements OnModuleInit {
       .createQueryBuilder('market')
       .leftJoinAndSelect('market.vault', 'vault')
       .where('market.vault_id = :vaultId', { vaultId })
+      .andWhere('vault.has_active_lp = true')
       .getOne();
 
     if (!item) {
@@ -229,7 +232,10 @@ export class MarketService implements OnModuleInit {
 
   /** Full load: vault + social_links, vault_image, ft_token_img, tags. Use for getMarketById. */
   private async getRawMarketByVaultIdWithRelations(vaultId: string): Promise<Market> {
-    const item = await this.createBaseQuery().where('market.vault_id = :vaultId', { vaultId }).getOne();
+    const item = await this.createBaseQuery()
+      .where('market.vault_id = :vaultId', { vaultId })
+      .andWhere('vault.has_active_lp = true')
+      .getOne();
 
     if (!item) {
       throw new NotFoundException(`Market not found for vault ${vaultId}`);

--- a/src/modules/vaults/market-stats/vault-market-stats.service.ts
+++ b/src/modules/vaults/market-stats/vault-market-stats.service.ts
@@ -179,24 +179,8 @@ export class VaultMarketStatsService {
           if (!liquidityCheck?.hasLiquidity) {
             this.logger.debug(`${vault.name}: No liquidity detected by DexHunter, skipping Taptools API`);
 
-            // Update LP status to false and record check time
+            // Update LP status to false and record check time, but do NOT upsert market data
             await this.vaultRepository.update({ id: vault.id }, { has_active_lp: false, lp_last_checked: new Date() });
-
-            // Update market stats with no market data (but still record the check)
-            await this.upsertMarketData({
-              vault_id: vault.id,
-              circSupply: 0,
-              mcap: 0,
-              totalSupply: 0,
-              price_change_1h: 0,
-              price_change_24h: 0,
-              price_change_7d: 0,
-              price_change_30d: 0,
-              tvl: vault.total_assets_cost_ada || 0,
-              has_market_data: false,
-              totalAdaLiquidity: null,
-              fdv_per_asset: null,
-            });
 
             return null; // Skip Taptools since no LP exists
           }


### PR DESCRIPTION
This pull request strengthens the enforcement of the `has_active_lp` flag across the market service, ensuring that only vaults with active liquidity providers are included in market queries and retrievals. Additionally, it clarifies the logic in the vault market stats service to prevent unnecessary market data upserts when a vault has no liquidity.

**Market query filtering:**
* All market queries in `MarketService` now explicitly filter for vaults where `has_active_lp = true`, ensuring only vaults with active liquidity providers are considered in listings and lookups. [[1]](diffhunk://#diff-9c96160765229d5f8d6263c3b758773b0341f420fb27a6629d005c0289d25d4fR123-R124) [[2]](diffhunk://#diff-9c96160765229d5f8d6263c3b758773b0341f420fb27a6629d005c0289d25d4fR223) [[3]](diffhunk://#diff-9c96160765229d5f8d6263c3b758773b0341f420fb27a6629d005c0289d25d4fL232-R238)

**Market data upsert logic:**
* The `VaultMarketStatsService` no longer upserts market data when no liquidity is detected for a vault; it only updates the LP status and check time, preventing unnecessary or misleading market data entries.