### PR TITLE
ADDED: fetching active policies to filter vaults

### DIFF
--- a/src/modules/vaults/dto/get-assets-whitelist.dto.ts
+++ b/src/modules/vaults/dto/get-assets-whitelist.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+import { PaginationDto } from './pagination.dto';
+
+export class GetAssetsWhitelistDto extends PaginationDto {
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'Return whitelist entries from my vaults (including drafts)',
+  })
+  @Expose()
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return value === 'true';
+    }
+
+    return value;
+  })
+  myVaults?: boolean;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Search by policy ID or collection name',
+  })
+  @Expose()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  search?: string;
+}

--- a/src/modules/vaults/dto/get-vaults.dto.ts
+++ b/src/modules/vaults/dto/get-vaults.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsBoolean, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
 
 import { PaginationDto } from './pagination.dto';
 
@@ -209,16 +209,35 @@ export class GetVaultsDto extends PaginationDto {
   @Type(() => Number)
   maxInitialVaultOffered?: number;
 
-  @IsString()
+  @IsArray()
+  @IsString({ each: true })
   @IsOptional()
   @ApiProperty({
-    type: String,
+    type: [String],
     required: false,
-    description: 'Filter by asset whitelist (exact match)',
+    description: 'Filter by asset whitelist policy IDs',
   })
   @Expose()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  assetWhitelist?: string;
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      const trimmedValue = value.trim();
+      return trimmedValue ? [trimmedValue] : [];
+    }
+
+    if (Array.isArray(value)) {
+      return Array.from(
+        new Set(
+          value
+            .filter(item => typeof item === 'string')
+            .map(item => item.trim())
+            .filter(item => item.length > 0)
+        )
+      );
+    }
+
+    return value;
+  })
+  assetWhitelist?: string[];
 
   // TVL Range
   @IsNumber()

--- a/src/modules/vaults/vaults.controller.ts
+++ b/src/modules/vaults/vaults.controller.ts
@@ -23,6 +23,7 @@ import { DraftVaultsService } from './draft-vaults.service';
 import { BuildBurnTransactionRes } from './dto/build-burn-transaction.res';
 import { CreateVaultRes } from './dto/create-vault.res';
 import { CreateVaultReq } from './dto/createVault.req';
+import { GetAssetsWhitelistDto } from './dto/get-assets-whitelist.dto';
 import {
   CollectionNameItem,
   GetCollectionNamesReq,
@@ -148,6 +149,21 @@ export class VaultsController {
   @Get('acquire/top')
   async getTopPublicAcquireVaults(): Promise<VaultAcquireResponse[]> {
     return this.vaultsService.getTopPublicAcquireVaults();
+  }
+
+  @ApiDoc({
+    summary: 'Get unique assets whitelist',
+    description:
+      'Returns paginated unique assets from assets whitelist as collection name and policy ID. Supports myVaults, page, limit and search query params.',
+    status: 200,
+  })
+  @UseGuards(OptionalAuthGuard)
+  @Get('assets-whitelist')
+  async getAssetsWhitelist(
+    @Query() query: GetAssetsWhitelistDto,
+    @Request() req?: AuthRequest
+  ): Promise<PaginatedResponseDto<{ name: string; policyId: string }>> {
+    return this.vaultsService.getAssetsWhitelist({ ...query, userId: req?.user?.sub });
   }
 
   @ApiDoc({

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -11,6 +11,7 @@ import { PriceService } from '../price/price.service';
 import { WayUpPricingService } from '../wayup/wayup-pricing.service';
 
 import { CreateVaultReq } from './dto/createVault.req';
+import { GetAssetsWhitelistDto } from './dto/get-assets-whitelist.dto';
 import { VaultActivityFilter } from './dto/get-vault-activity.dto';
 import { GetVaultsDto, SortOrder, TVLCurrency, VaultFilter } from './dto/get-vaults.dto';
 import { IncrementViewCountRes } from './dto/increment-view-count.res';
@@ -54,6 +55,7 @@ import { TransactionStatus, TransactionType } from '@/types/transaction.types';
 import {
   ContributionWindowType,
   InvestmentWindowType,
+  VAULT_SEARCH_STATUSES,
   ValueMethod,
   VaultPrivacy,
   VaultStatus,
@@ -1356,15 +1358,7 @@ export class VaultsService {
           queryBuilder.andWhere('vault.vault_status = :status', { status: VaultStatus.published });
           break;
         case VaultFilter.all: {
-          const statuses = [
-            VaultStatus.published,
-            VaultStatus.expansion,
-            VaultStatus.contribution,
-            VaultStatus.acquire,
-            VaultStatus.locked,
-            VaultStatus.terminating,
-            VaultStatus.burned,
-          ];
+          const statuses = [...VAULT_SEARCH_STATUSES];
 
           if (myVaults) {
             statuses.push(VaultStatus.draft);
@@ -1429,13 +1423,13 @@ export class VaultsService {
       queryBuilder.andWhere('(100 - vault.acquire_reserve) >= :minInitialVaultOffered', { minInitialVaultOffered });
     }
 
-    if (assetWhitelist) {
+    if (assetWhitelist?.length) {
       queryBuilder.andWhere(
         `EXISTS (
           SELECT 1 
           FROM assets_whitelist aw 
           WHERE aw.vault_id = vault.id 
-          AND aw.policy_id = :assetWhitelist
+          AND aw.policy_id IN (:...assetWhitelist)
         )`,
         { assetWhitelist }
       );
@@ -1611,6 +1605,71 @@ export class VaultsService {
     }
 
     return { success: true };
+  }
+
+  async getAssetsWhitelist(
+    query: GetAssetsWhitelistDto & { userId?: string }
+  ): Promise<PaginatedResponseDto<{ name: string; policyId: string }>> {
+    const { myVaults = false, userId, page = 1, limit = 10, search } = query;
+    const statuses = [...VAULT_SEARCH_STATUSES];
+    const includeDrafts = Boolean(myVaults && userId);
+    const safePage = page > 0 ? page : 1;
+    const safeLimit = limit > 0 ? limit : 10;
+    const offset = (safePage - 1) * safeLimit;
+
+    if (includeDrafts) {
+      statuses.push(VaultStatus.draft);
+    }
+
+    const baseQuery = this.assetsWhitelistRepository
+      .createQueryBuilder('assets_whitelist')
+      .innerJoin('assets_whitelist.vault', 'vault')
+      .select('assets_whitelist.policy_id', 'policyId')
+      .addSelect("MIN(NULLIF(assets_whitelist.collection_name, ''))", 'name')
+      .where('vault.vault_status IN (:...statuses)', { statuses })
+      .andWhere('vault.deleted != :deleted', { deleted: true });
+
+    if (includeDrafts) {
+      baseQuery.andWhere('vault.owner_id = :userId', { userId });
+    } else {
+      baseQuery.andWhere('vault.privacy = :publicPrivacy', { publicPrivacy: VaultPrivacy.public });
+    }
+
+    if (search?.trim()) {
+      baseQuery.andWhere(
+        new Brackets(qb => {
+          qb.where('assets_whitelist.policy_id ILIKE :search', { search: `%${search.trim()}%` }).orWhere(
+            'assets_whitelist.collection_name ILIKE :search',
+            { search: `%${search.trim()}%` }
+          );
+        })
+      );
+    }
+
+    const totalRaw = await baseQuery
+      .clone()
+      .select('COUNT(DISTINCT assets_whitelist.policy_id)', 'total')
+      .getRawOne<{ total: string }>();
+
+    const total = Number(totalRaw?.total || 0);
+
+    const rows = await baseQuery
+      .groupBy('assets_whitelist.policy_id')
+      .orderBy("MIN(NULLIF(assets_whitelist.collection_name, ''))", 'ASC')
+      .offset(offset)
+      .limit(safeLimit)
+      .getRawMany<{ policyId: string; name: string | null }>();
+
+    return {
+      items: rows.map(item => ({
+        name: item.name || item.policyId,
+        policyId: item.policyId,
+      })),
+      total,
+      page: safePage,
+      limit: safeLimit,
+      totalPages: Math.ceil(total / safeLimit),
+    };
   }
 
   /**

--- a/src/types/vault.types.ts
+++ b/src/types/vault.types.ts
@@ -61,6 +61,16 @@ export enum VaultStatus {
   expansion = 'expansion',
 }
 
+export const VAULT_SEARCH_STATUSES: VaultStatus[] = [
+  VaultStatus.published,
+  VaultStatus.expansion,
+  VaultStatus.contribution,
+  VaultStatus.acquire,
+  VaultStatus.locked,
+  VaultStatus.terminating,
+  VaultStatus.burned,
+];
+
 // Mapping for smart contract vault status
 export enum SmartContractVaultStatus {
   PENDING = 0,


### PR DESCRIPTION
This pull request adds a new paginated endpoint to fetch unique asset whitelist entries (policy IDs and collection names) and refactors the handling of asset whitelist filtering in vault queries. It also introduces a new constant for vault search statuses to improve maintainability and consistency.

### New features

* Added a new paginated endpoint `GET /vaults/assets-whitelist` to retrieve unique asset whitelist entries, supporting filtering by user vaults (`myVaults`), search, and pagination. [[1]](diffhunk://#diff-9caf7966fea08a001a815233e789aaa8695c1dc437e21cbc5e7415a54300d8e5R154-R168) [[2]](diffhunk://#diff-57d13e50954b2feb99e7a95829a74f8f404f526a2c12802fc35c943271c1b8c5R1-R35) [[3]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R1610-R1669)

### Refactoring and improvements

* Refactored asset whitelist filtering in `GetVaultsDto` and `VaultsService` to accept an array of policy IDs instead of a single string, enabling multi-policy filtering. [[1]](diffhunk://#diff-2b11d887604cebc1e6fac73cbce5c58c2a743c88ba87118d07ce418daabf6136L212-R232) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L1432-R1432)
* Introduced the `VAULT_SEARCH_STATUSES` constant for consistent status filtering logic across the codebase. [[1]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L1359-R1361) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R58) [[3]](diffhunk://#diff-82ceaae7da15f0c5e22ae6bc45b4593e5917511968dbe38835b8af16ee8e1199R64-R73)

### Code organization

* Added and updated DTOs and imports to support the new endpoint and refactored logic, including the creation of `GetAssetsWhitelistDto`. [[1]](diffhunk://#diff-57d13e50954b2feb99e7a95829a74f8f404f526a2c12802fc35c943271c1b8c5R1-R35) [[2]](diffhunk://#diff-9caf7966fea08a001a815233e789aaa8695c1dc437e21cbc5e7415a54300d8e5R26) [[3]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R14)