### PR TITLE
ADDED: time limit for transaction confirmation

### DIFF
--- a/src/modules/stake/stake.service.ts
+++ b/src/modules/stake/stake.service.ts
@@ -29,6 +29,7 @@ import { TransactionStatus, TransactionType } from '@/types/transaction.types';
 
 /** Transaction types built from the admin wallet and requiring admin co-sign on submit. */
 const ADMIN_SIGNED_TYPES = [TransactionType.unstake, TransactionType.harvest, TransactionType.compound];
+const TX_VALIDITY_WINDOW_MS = 30 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Module-level pure helpers
@@ -715,7 +716,10 @@ export class StakeService {
         );
       }
 
-      const tx = await txBuilder.addSignerKey(ownerHash).complete();
+      const tx = await txBuilder
+        .validTo(currentTimeMs + TX_VALIDITY_WINDOW_MS)
+        .addSignerKey(ownerHash)
+        .complete();
       const unsignedTxCbor = tx.toCBOR();
 
       const saved = await this.transactionRepository.save({
@@ -775,11 +779,13 @@ export class StakeService {
       );
 
       const redeemer = Data.to(new Constr(0, []));
+      const validTo = Date.now() + TX_VALIDITY_WINDOW_MS;
       const tx = await lucid
         .newTx()
         .readFrom([referenceUtxo])
         .collectFrom(eligibleBoxes, redeemer)
         .pay.ToAddress(userAddress, Object.fromEntries(payoutByUnit.entries()))
+        .validTo(validTo)
         .addSignerKey(ownerHash)
         .complete();
 
@@ -825,6 +831,7 @@ export class StakeService {
       );
 
       const now = Date.now();
+      const validTo = now + TX_VALIDITY_WINDOW_MS;
       const redeemer = Data.to(new Constr(0, []));
       let txBuilder = lucid.newTx().readFrom([referenceUtxo]).collectFrom(eligibleBoxes, redeemer);
 
@@ -841,7 +848,7 @@ export class StakeService {
 
       txBuilder = txBuilder.pay.ToAddress(userAddress, Object.fromEntries(rewardByUnit.entries()));
 
-      const tx = await txBuilder.addSignerKey(ownerHash).complete();
+      const tx = await txBuilder.validTo(validTo).addSignerKey(ownerHash).complete();
       const unsignedTxCbor = tx.toCBOR();
 
       const saved = await this.transactionRepository.save({
@@ -885,6 +892,7 @@ export class StakeService {
       );
 
       const now = Date.now();
+      const validTo = now + TX_VALIDITY_WINDOW_MS;
       const redeemer = Data.to(new Constr(0, []));
       let txBuilder = lucid.newTx().readFrom([referenceUtxo]).collectFrom(eligibleBoxes, redeemer);
 
@@ -897,7 +905,7 @@ export class StakeService {
         );
       }
 
-      const tx = await txBuilder.addSignerKey(ownerHash).complete();
+      const tx = await txBuilder.validTo(validTo).addSignerKey(ownerHash).complete();
       const unsignedTxCbor = tx.toCBOR();
 
       const saved = await this.transactionRepository.save({


### PR DESCRIPTION
This pull request improves the transaction validity handling in the `StakeService` by ensuring all constructed transactions have a bounded validity window. The main changes involve consistently setting a `validTo` timestamp for transactions, which helps prevent replay attacks and ensures transactions are only valid for a limited period after creation.

**Transaction validity improvements:**

* Introduced a module-level constant `TX_VALIDITY_WINDOW_MS` (set to 30 minutes) to standardize the transaction validity window across the service.
* Updated all transaction-building logic to include a `.validTo(validTo)` call, ensuring each transaction expires 30 minutes after creation. This affects unstake, harvest, and compound transaction flows. [[1]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53L718-R722) [[2]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53R782-R788) [[3]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53R834) [[4]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53L844-R851) [[5]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53R895) [[6]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53L900-R908)