### PR TITLE
Remove debug logging for cached token prices in pricing services

### DIFF
--- a/src/modules/dexhunter/dexhunter-pricing.service.ts
+++ b/src/modules/dexhunter/dexhunter-pricing.service.ts
@@ -123,7 +123,6 @@ export class DexHunterPricingService {
     const cacheKey = `token_price_${tokenId}`;
     const cached = this.priceCache.get<number | null>(cacheKey);
     if (cached !== undefined) {
-      this.logger.debug(`Using cached price for token ${tokenId}: ${cached} ADA`);
       return cached;
     }
 

--- a/src/modules/wayup/wayup-pricing.service.ts
+++ b/src/modules/wayup/wayup-pricing.service.ts
@@ -157,7 +157,6 @@ export class WayUpPricingService {
       hasListings: boolean;
     }>(cacheKey);
     if (cached !== undefined) {
-      this.logger.debug(`Using cached floor price for collection ${policyId}: ${cached.floorPriceAda} ADA`);
       return cached;
     }
 


### PR DESCRIPTION
This pull request makes minor changes to the logging behavior in the pricing services for both DexHunter and WayUp modules. Specifically, it removes debug log statements that printed cached price information when a cache hit occurred.

Logging changes:

* Removed debug log statement in `DexHunterPricingService` that logged the cached token price when returning from cache. (`src/modules/dexhunter/dexhunter-pricing.service.ts`)
* Removed debug log statement in `WayUpPricingService` that logged the cached floor price for a collection when returning from cache. (`src/modules/wayup/wayup-pricing.service.ts`)