### PR TITLE
Refine asset count cap types to bigint and update validation logic

### DIFF
--- a/src/database/assetsWhitelist.entity.ts
+++ b/src/database/assetsWhitelist.entity.ts
@@ -31,7 +31,7 @@ export class AssetsWhitelistEntity {
   collection_name?: string;
 
   @Expose({ name: 'countCapMin' })
-  @Transform(({ value }) => (value ? Number(value) : null))
+  @Transform(({ value }) => (value !== null && value !== undefined ? Number(value) : null))
   @Column({
     name: 'asset_count_cap_min',
     type: 'bigint',
@@ -40,7 +40,7 @@ export class AssetsWhitelistEntity {
   asset_count_cap_min?: number;
 
   @Expose({ name: 'countCapMax' })
-  @Transform(({ value }) => (value ? Number(value) : null))
+  @Transform(({ value }) => (value !== null && value !== undefined ? Number(value) : null))
   @Column({
     name: 'asset_count_cap_max',
     type: 'bigint',

--- a/src/database/assetsWhitelist.entity.ts
+++ b/src/database/assetsWhitelist.entity.ts
@@ -33,7 +33,7 @@ export class AssetsWhitelistEntity {
   @Expose({ name: 'countCapMin' })
   @Column({
     name: 'asset_count_cap_min',
-    type: 'integer',
+    type: 'bigint',
     nullable: true,
   })
   asset_count_cap_min?: number;
@@ -41,7 +41,7 @@ export class AssetsWhitelistEntity {
   @Expose({ name: 'countCapMax' })
   @Column({
     name: 'asset_count_cap_max',
-    type: 'integer',
+    type: 'bigint',
     nullable: true,
   })
   asset_count_cap_max?: number;

--- a/src/database/assetsWhitelist.entity.ts
+++ b/src/database/assetsWhitelist.entity.ts
@@ -1,4 +1,4 @@
-import { Expose } from 'class-transformer';
+import { Expose, Transform } from 'class-transformer';
 import { Matches } from 'class-validator';
 import {
   BeforeInsert,
@@ -31,6 +31,7 @@ export class AssetsWhitelistEntity {
   collection_name?: string;
 
   @Expose({ name: 'countCapMin' })
+  @Transform(({ value }) => (value ? Number(value) : null))
   @Column({
     name: 'asset_count_cap_min',
     type: 'bigint',
@@ -39,6 +40,7 @@ export class AssetsWhitelistEntity {
   asset_count_cap_min?: number;
 
   @Expose({ name: 'countCapMax' })
+  @Transform(({ value }) => (value ? Number(value) : null))
   @Column({
     name: 'asset_count_cap_max',
     type: 'bigint',

--- a/src/database/migrations/1777939200123-ChangeAssetCountCapsToBigint.ts
+++ b/src/database/migrations/1777939200123-ChangeAssetCountCapsToBigint.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChangeAssetCountCapsToBigint1777939200123 implements MigrationInterface {
+  name = 'ChangeAssetCountCapsToBigint1777939200123';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Change asset_count_cap_min from integer to bigint
+    await queryRunner.query(
+      `ALTER TABLE "assets_whitelist" ALTER COLUMN "asset_count_cap_min" TYPE bigint USING "asset_count_cap_min"::bigint`
+    );
+
+    // Change asset_count_cap_max from integer to bigint
+    await queryRunner.query(
+      `ALTER TABLE "assets_whitelist" ALTER COLUMN "asset_count_cap_max" TYPE bigint USING "asset_count_cap_max"::bigint`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert asset_count_cap_max back to integer
+    // Note: This will fail if values exceed integer max (2,147,483,647)
+    await queryRunner.query(
+      `ALTER TABLE "assets_whitelist" ALTER COLUMN "asset_count_cap_max" TYPE integer USING "asset_count_cap_max"::integer`
+    );
+
+    // Revert asset_count_cap_min back to integer
+    // Note: This will fail if values exceed integer max (2,147,483,647)
+    await queryRunner.query(
+      `ALTER TABLE "assets_whitelist" ALTER COLUMN "asset_count_cap_min" TYPE integer USING "asset_count_cap_min"::integer`
+    );
+  }
+}

--- a/src/modules/vaults/dto/assetWhitelist.dto.ts
+++ b/src/modules/vaults/dto/assetWhitelist.dto.ts
@@ -1,6 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsString, IsNumber, IsOptional, Matches, IsEnum, ValidateIf, Min, Max, IsBoolean } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  IsInt,
+  IsOptional,
+  Matches,
+  IsEnum,
+  ValidateIf,
+  Min,
+  Max,
+  IsBoolean,
+} from 'class-validator';
 
 import { AssetValuationMethod } from '@/types/asset.types';
 
@@ -73,7 +84,7 @@ export class AssetWhitelistDto {
     maximum: 1000000000000,
   })
   @IsOptional()
-  @IsNumber()
+  @IsInt()
   @Min(0)
   @Max(1000000000000, { message: 'Count cap minimum cannot exceed 1 trillion' })
   @Expose({ name: 'countCapMin' })
@@ -87,7 +98,7 @@ export class AssetWhitelistDto {
     maximum: 1000000000000,
   })
   @IsOptional()
-  @IsNumber()
+  @IsInt()
   @Min(0)
   @Max(1000000000000, { message: 'Count cap maximum cannot exceed 1 trillion' })
   @Expose({ name: 'countCapMax' })

--- a/src/modules/vaults/dto/assetWhitelist.dto.ts
+++ b/src/modules/vaults/dto/assetWhitelist.dto.ts
@@ -69,9 +69,13 @@ export class AssetWhitelistDto {
     description: 'Minimum number of assets allowed',
     required: false,
     example: 1,
+    minimum: 0,
+    maximum: 1000000000000,
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
+  @Max(1000000000000, { message: 'Count cap minimum cannot exceed 1 trillion' })
   @Expose({ name: 'countCapMin' })
   countCapMin?: number;
 
@@ -79,9 +83,13 @@ export class AssetWhitelistDto {
     description: 'Maximum number of assets allowed',
     required: false,
     example: 10,
+    minimum: 0,
+    maximum: 1000000000000,
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
+  @Max(1000000000000, { message: 'Count cap maximum cannot exceed 1 trillion' })
   @Expose({ name: 'countCapMax' })
   countCapMax?: number;
 

--- a/src/modules/vaults/phase-management/contribution/contribution.service.ts
+++ b/src/modules/vaults/phase-management/contribution/contribution.service.ts
@@ -18,7 +18,7 @@ import { VaultStatus } from '@/types/vault.types';
 // Maximum safe quantity for JavaScript number handling
 // Using Number.MAX_SAFE_INTEGER (2^53 - 1) to prevent precision loss
 const MAX_SAFE_QUANTITY = Number.MAX_SAFE_INTEGER; // 9,007,199,254,740,991
-const LARGE_QUANTITY_WARNING_THRESHOLD = 1000000000; // 1 billion
+const LARGE_QUANTITY_WARNING_THRESHOLD = 1000000000000; // 1 trillion
 
 @Injectable()
 export class ContributionService {
@@ -237,14 +237,14 @@ export class ContributionService {
 
         if (
           whitelistedAsset.asset_count_cap_max !== null &&
-          whitelistedAsset.asset_count_cap_max > 0 &&
-          existingPolicyCount + policyAssetsQuantity > whitelistedAsset.asset_count_cap_max
+          Number(whitelistedAsset.asset_count_cap_max) > 0 &&
+          existingPolicyCount + policyAssetsQuantity > Number(whitelistedAsset.asset_count_cap_max)
         ) {
           policyExceedsLimit.push({
             policyId,
             existing: existingPolicyCount,
             adding: policyAssetsQuantity,
-            max: whitelistedAsset.asset_count_cap_max,
+            max: Number(whitelistedAsset.asset_count_cap_max),
           });
         }
       }

--- a/src/modules/vaults/processing-tx/onchain/blockchain.service.ts
+++ b/src/modules/vaults/processing-tx/onchain/blockchain.service.ts
@@ -219,7 +219,7 @@ export class BlockchainService {
    * @param signedTx Signed transaction data
    * @returns Transaction hash
    */
-  async   submitTransaction(signedTx: {
+  async submitTransaction(signedTx: {
     transaction: string;
     signatures?: string[];
   }): Promise<TransactionSubmitResponse> {

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -476,7 +476,7 @@ export class VaultsService {
             .execute();
 
           if (result.identifiers.length > 0 && assetItem.countCapMax) {
-            maxCountOf += assetItem.countCapMax;
+            maxCountOf += Number(assetItem.countCapMax);
           }
         })
       );


### PR DESCRIPTION
This pull request updates how asset count caps are handled in the codebase to support much larger values, switching from `integer` to `bigint` in the database and aligning validation and transformation logic throughout the application. The changes ensure that asset count caps can now safely support values up to 1 trillion, with consistent validation and type handling.

**Database changes:**

* Changed the type of `asset_count_cap_min` and `asset_count_cap_max` columns in the `assets_whitelist` table from `integer` to `bigint` to support larger values, and added a migration to perform this schema change. [[1]](diffhunk://#diff-33777252b6496c1bb48e2d8ec5bc4d31ede1946af3e6de84795c8f171c1679b8R34-R46) [[2]](diffhunk://#diff-5f189de812e5ae871999888139c3bd69fa87f2acf136b93fa0557ea6102b1e26R1-R31)

**DTO and validation improvements:**

* Updated the `AssetWhitelistDto` to use `@IsInt`, `@Min(0)`, and `@Max(1000000000000)` validators for `countCapMin` and `countCapMax`, ensuring values are integers between 0 and 1 trillion, and improved API documentation accordingly.

**Serialization and transformation:**

* Added `@Transform` decorators to ensure `asset_count_cap_min` and `asset_count_cap_max` are always deserialized as numbers, preventing type mismatches when working with `bigint` values.

**Business logic and limits:**

* Updated the large quantity warning threshold to 1 trillion and ensured all relevant business logic (such as policy checks and calculations) consistently casts count cap values to numbers to avoid errors with `bigint` types. [[1]](diffhunk://#diff-64a6081150076f850966de91db78be6bca4a1b124490727ecccdd900c6734083L21-R21) [[2]](diffhunk://#diff-64a6081150076f850966de91db78be6bca4a1b124490727ecccdd900c6734083L240-R247) [[3]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L479-R479)