### PR TITLE
ADDED: collection name to expansionAssetsByPolicy

### DIFF
--- a/src/modules/vaults/dto/vault.response.ts
+++ b/src/modules/vaults/dto/vault.response.ts
@@ -717,12 +717,24 @@ export class VaultFullResponse extends VaultShortResponse {
   })
   expansionNoLimit?: boolean;
 
-  @ApiProperty({ description: 'Expansion assets grouped by policy', required: false })
+  @ApiProperty({
+    description: 'Expansion assets grouped by policy',
+    required: false,
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        policyId: { type: 'string' },
+        quantity: { type: 'number' },
+        collectionName: { type: 'string', nullable: true },
+      },
+    },
+  })
   @DtoRepresent({
     transform: false,
     expose: { name: 'expansionAssetsByPolicy' },
   })
-  expansionAssetsByPolicy?: Array<{ policyId: string; quantity: number }>;
+  expansionAssetsByPolicy?: Array<{ policyId: string; quantity: number; collectionName: string | null }>;
 
   @ApiProperty({
     description: 'Expansion whitelisted collections with names',

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -921,7 +921,7 @@ export class VaultsService {
     let expansionNoLimit: boolean | undefined;
     let expansionPriceType: 'limit' | 'market' | undefined;
     let expansionLimitPrice: number | undefined;
-    let expansionAssetsByPolicy: Array<{ policyId: string; quantity: number }> = [];
+    let expansionAssetsByPolicy: Array<{ policyId: string; quantity: number; collectionName: string | null }> = [];
     let expansionWhitelist: Array<{ policyId: string; collectionName: string | null }> = [];
 
     // Only check vault_status to determine if vault is currently in expansion
@@ -991,7 +991,8 @@ export class VaultsService {
           .getRawMany();
 
         // Group by policy and sum quantities (with decimal adjustment for FTs)
-        const policyMap = new Map<string, number>();
+        // Pre-fill expansion policies with 0 so frontend can show them even before first contribution.
+        const policyMap = new Map<string, number>(expansionWhitelist.map(item => [item.policyId, 0] as const));
 
         for (const row of expansionAssetData) {
           const policyId = row.policyId;
@@ -1007,16 +1008,15 @@ export class VaultsService {
                 ? ftQuantityRaw / Math.pow(10, decimals)
                 : ftQuantityRaw;
 
-          if (policyMap.has(policyId)) {
-            policyMap.set(policyId, policyMap.get(policyId)! + quantity);
-          } else {
-            policyMap.set(policyId, quantity);
-          }
+          policyMap.set(policyId, (policyMap.get(policyId) ?? 0) + quantity);
         }
+
+        const expansionNameByPolicy = new Map(expansionWhitelist.map(w => [w.policyId, w.collectionName] as const));
 
         expansionAssetsByPolicy = Array.from(policyMap.entries()).map(([policyId, quantity]) => ({
           policyId,
           quantity,
+          collectionName: expansionNameByPolicy.get(policyId) ?? null,
         }));
 
         expansionAssetsCount = Array.from(policyMap.values()).reduce((sum, qty) => sum + qty, 0);


### PR DESCRIPTION
This pull request improves the handling and representation of expansion assets grouped by policy in the vaults module. The main changes ensure that each expansion asset includes its associated collection name (if available), and that all expansion policies are represented in the response, even if their quantity is zero. This provides more complete and frontend-friendly data.

**API Response Improvements:**

* The `expansionAssetsByPolicy` property in the `VaultFullResponse` DTO now includes the `collectionName` for each policy, and its OpenAPI schema is updated to reflect this change.

**Backend Logic Enhancements:**

* The `expansionAssetsByPolicy` array in `VaultsService` now includes `collectionName` for each policy, aligning with the updated DTO.
* The backend logic pre-fills all policies from the whitelist with a quantity of zero, ensuring the frontend receives a complete list of policies, even if some have no contributions yet.
* When building `expansionAssetsByPolicy`, the code now attaches the correct `collectionName` to each policy using a mapping from the whitelist.