### PR TITLE
Refactor valuation method assignment for LP tokens in services

### DIFF
--- a/src/modules/vaults/draft-vaults.service.ts
+++ b/src/modules/vaults/draft-vaults.service.ts
@@ -324,18 +324,8 @@ export class DraftVaultsService {
                   `Please ensure the LP token has a valid pool ID before adding it to the vault.`
               );
             }
-            if (
-              whitelistItem.valuationMethod &&
-              whitelistItem.valuationMethod !== AssetValuationMethod.LP_TOKEN_DYNAMIC
-            ) {
-              throw new BadRequestException(
-                `Policy ${whitelistItem.policyId} is an LP token and must use "lp_token_dynamic" valuation method.`
-              );
-            }
-            // Auto-set if not provided
-            if (!whitelistItem.valuationMethod) {
-              whitelistItem.valuationMethod = AssetValuationMethod.LP_TOKEN_DYNAMIC;
-            }
+            // Auto-set to LP_TOKEN_DYNAMIC for LP tokens
+            whitelistItem.valuationMethod = AssetValuationMethod.LP_TOKEN_DYNAMIC;
           } else if (whitelistItem.valuationMethod === AssetValuationMethod.LP_TOKEN_DYNAMIC) {
             // Non-LP token attempting to use lp_token_dynamic
             throw new BadRequestException(

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -418,15 +418,8 @@ export class VaultsService {
                 `Please ensure the LP token has a valid pool ID before adding it to the vault.`
             );
           }
-          if (assetItem.valuationMethod && assetItem.valuationMethod !== AssetValuationMethod.LP_TOKEN_DYNAMIC) {
-            throw new BadRequestException(
-              `Policy ${assetItem.policyId} is an LP token and must use "lp_token_dynamic" valuation method.`
-            );
-          }
-          // Auto-set if not provided
-          if (!assetItem.valuationMethod) {
-            assetItem.valuationMethod = AssetValuationMethod.LP_TOKEN_DYNAMIC;
-          }
+          // Auto-set to LP_TOKEN_DYNAMIC for LP tokens
+          assetItem.valuationMethod = AssetValuationMethod.LP_TOKEN_DYNAMIC;
         } else if (assetItem.valuationMethod === AssetValuationMethod.LP_TOKEN_DYNAMIC) {
           // Non-LP token attempting to use lp_token_dynamic
           throw new BadRequestException(


### PR DESCRIPTION
This pull request updates the logic for setting the valuation method of LP tokens in both the `DraftVaultsService` and `VaultsService`. The main change is to always auto-set the valuation method to `LP_TOKEN_DYNAMIC` for LP tokens, regardless of any existing value, and to remove the previous validation that would throw an error if a different valuation method was provided.

Key changes:

**Vaults & Draft Vaults Valuation Method Handling:**

* In both `draft-vaults.service.ts` and `vaults.service.ts`, the code now always auto-sets the `valuationMethod` to `LP_TOKEN_DYNAMIC` for LP tokens, removing the previous check that would throw an error if a different method was set. [[1]](diffhunk://#diff-ebb6fc2e455f893b11a0ded7eaf16fe1f0458adbc64f79f8016fd37850325683L327-L338) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L421-L429)
* The code continues to throw an error if a non-LP token tries to use the `LP_TOKEN_DYNAMIC` valuation method. [[1]](diffhunk://#diff-ebb6fc2e455f893b11a0ded7eaf16fe1f0458adbc64f79f8016fd37850325683L327-L338) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L421-L429)