### PR TITLE
ADDED: upcoming status to cancel vault

### DIFF
--- a/src/modules/vaults/vaults-admin/vaults-admin.service.ts
+++ b/src/modules/vaults/vaults-admin/vaults-admin.service.ts
@@ -9,7 +9,12 @@ import { ClaimsService } from '@/modules/vaults/claims/claims.service';
 import { PaginatedResponseDto } from '@/modules/vaults/dto/paginated-response.dto';
 import { VaultManagingService } from '@/modules/vaults/processing-tx/onchain/vault-managing.service';
 import { TransactionStatus, TransactionType } from '@/types/transaction.types';
-import { SmartContractVaultStatus, VaultFailureReason, VaultStatus } from '@/types/vault.types';
+import {
+  SmartContractVaultStatus,
+  VaultFailureReason,
+  VaultStatus,
+  VAULT_CANCELLABLE_STATUSES,
+} from '@/types/vault.types';
 
 @Injectable()
 export class VaultsAdminService {
@@ -34,8 +39,7 @@ export class VaultsAdminService {
     const safePage = page > 0 ? page : 1;
     const safeLimit = limit > 0 ? limit : 10;
     const offset = (safePage - 1) * safeLimit;
-    const now = Date.now();
-    const oneDayAgo = new Date(now - 86_400_000);
+    const oneDayAgo = new Date(Date.now() - 86_400_000);
 
     const queryBuilder = this.vaultsRepository
       .createQueryBuilder('vault')
@@ -43,16 +47,14 @@ export class VaultsAdminService {
       .where('vault.deleted = false')
       .andWhere(
         new Brackets(qb => {
-          qb.where(
-            'vault.vault_status = :contributionStatus AND vault.contribution_phase_start IS NOT NULL AND vault.contribution_phase_start >= :oneDayAgo',
+          qb.where('vault.vault_status = :publishedStatus', {
+            publishedStatus: VaultStatus.published,
+          }).orWhere(
+            `vault.vault_status = :contributionStatus AND (
+              vault.contribution_phase_start IS NULL OR vault.contribution_phase_start >= :oneDayAgo
+            )`,
             {
               contributionStatus: VaultStatus.contribution,
-              oneDayAgo,
-            }
-          ).orWhere(
-            'vault.vault_status = :acquireStatus AND vault.acquire_phase_start IS NOT NULL AND vault.acquire_phase_start >= :oneDayAgo',
-            {
-              acquireStatus: VaultStatus.acquire,
               oneDayAgo,
             }
           );
@@ -131,21 +133,19 @@ export class VaultsAdminService {
   }
 
   private async canCancelVaultByAdmin(vault: Vault): Promise<boolean> {
-    const cancellableStatuses: VaultStatus[] = [VaultStatus.contribution];
-    if (!cancellableStatuses.includes(vault.vault_status)) {
+    if (!VAULT_CANCELLABLE_STATUSES.includes(vault.vault_status)) {
       return false;
     }
 
-    const oneDayMs = 86_400_000;
-    const phaseStart = vault.contribution_phase_start;
-
-    if (!phaseStart) {
-      return false;
-    }
-
-    const ageMs = Date.now() - new Date(phaseStart).getTime();
-    if (ageMs > oneDayMs) {
-      return false;
+    if (vault.vault_status === VaultStatus.contribution) {
+      const oneDayMs = 86_400_000;
+      const phaseStart = vault.contribution_phase_start;
+      if (phaseStart) {
+        const ageMs = Date.now() - new Date(phaseStart).getTime();
+        if (ageMs > oneDayMs) {
+          return false;
+        }
+      }
     }
 
     const ownerId = vault.owner?.id;

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -57,6 +57,7 @@ import { TransactionStatus, TransactionType } from '@/types/transaction.types';
 import {
   ContributionWindowType,
   InvestmentWindowType,
+  VAULT_CANCELLABLE_STATUSES,
   VAULT_SEARCH_STATUSES,
   ValueMethod,
   VaultPrivacy,
@@ -2145,19 +2146,21 @@ export class VaultsService {
       throw new UnauthorizedException('You must be an owner of vault!');
     }
 
-    const cancellableStatuses: VaultStatus[] = [VaultStatus.contribution];
-    if (!cancellableStatuses.includes(vault.vault_status)) {
+    if (!VAULT_CANCELLABLE_STATUSES.includes(vault.vault_status)) {
       throw new BadRequestException('Vault cannot be cancelled in its current status');
     }
 
-    const oneDayMs = 86_400_000;
-    const phaseStart = vault.contribution_phase_start;
-    if (!phaseStart) {
-      throw new BadRequestException('Vault phase start is not defined');
-    }
-    const ageMs = Date.now() - new Date(phaseStart).getTime();
-    if (ageMs > oneDayMs) {
-      throw new BadRequestException('Vault can only be cancelled within 24 hours of creation');
+    if (vault.vault_status === VaultStatus.contribution) {
+      const oneDayMs = 86_400_000;
+      const phaseStart = vault.contribution_phase_start;
+      if (phaseStart) {
+        const ageMs = Date.now() - new Date(phaseStart).getTime();
+        if (ageMs > oneDayMs) {
+          throw new BadRequestException(
+            'Vault can only be cancelled within 24 hours after the contribution phase has started'
+          );
+        }
+      }
     }
 
     const hasForeignAssets = await this.assetsRepository

--- a/src/types/vault.types.ts
+++ b/src/types/vault.types.ts
@@ -71,6 +71,9 @@ export const VAULT_SEARCH_STATUSES: VaultStatus[] = [
   VaultStatus.burned,
 ];
 
+/** Vaults that owner or admin may cancel (upcoming + contribution), subject to other checks. */
+export const VAULT_CANCELLABLE_STATUSES: VaultStatus[] = [VaultStatus.published, VaultStatus.contribution];
+
 // Mapping for smart contract vault status
 export enum SmartContractVaultStatus {
   PENDING = 0,


### PR DESCRIPTION
This pull request updates the logic for vault cancellation and adjusts how vaults are filtered in admin queries. The main changes expand the set of vault statuses that can be cancelled and clarify the 24-hour cancellation window for contribution-phase vaults, while also simplifying the vault querying logic for admins.

**Vault cancellation logic updates:**

* Both admins and owners can now cancel vaults with status `published` in addition to those with status `contribution`, expanding the set of cancellable vaults. (`src/modules/vaults/vaults-admin/vaults-admin.service.ts`, `src/modules/vaults/vaults.service.ts`) [[1]](diffhunk://#diff-0cd752fb832153671e3b4979cc9f0a5ba6e9a1fd2115085252b26a22018fa0feL134-R143) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L2148-R2163)
* The 24-hour cancellation window for `contribution` phase vaults is now enforced only if the phase start date exists; if it does not, cancellation is allowed (admins) or not blocked with an exception (owners). The error message for owners has been clarified to specify the 24-hour window applies after the contribution phase starts. (`src/modules/vaults/vaults-admin/vaults-admin.service.ts`, `src/modules/vaults/vaults.service.ts`) [[1]](diffhunk://#diff-0cd752fb832153671e3b4979cc9f0a5ba6e9a1fd2115085252b26a22018fa0feL134-R143) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L2148-R2163)

**Vaults admin query simplification:**

* The vaults admin query now includes all `published` vaults, and only `contribution` phase vaults that started within the last 24 hours. The condition for `acquire` phase vaults has been removed, simplifying the query logic. (`src/modules/vaults/vaults-admin/vaults-admin.service.ts`)