### PR TITLE
ADDED: staking fee

### DIFF
--- a/src/modules/stake/stake.service.ts
+++ b/src/modules/stake/stake.service.ts
@@ -758,6 +758,8 @@ export class StakeService {
         );
       }
 
+      txBuilder = txBuilder.pay.ToAddress(this.adminAddress, { lovelace: 2_000_000n });
+
       const tx = await txBuilder
         .validTo(currentTimeMs + TX_VALIDITY_WINDOW_MS)
         .addSignerKey(ownerHash)


### PR DESCRIPTION
This pull request updates the `StakeService` to introduce a configurable flat protocol fee for staking transactions. The main changes ensure the protocol fee can be set via environment variables and is included in transaction construction.

**Configuration and Fee Handling Improvements:**

* Added a new `protocolFlatFee` property to `StakeService`, which is initialized from the `PROTOCOL_FLAT_FEE` environment variable (defaulting to `'2000000'` if not set). The value is parsed as a `bigint`, and an error is thrown if parsing fails. [[1]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53R97) [[2]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53R132-R138)

**Transaction Construction:**

* Updated the transaction builder to always include a payment of the protocol flat fee to the admin address as part of the staking transaction.