### PR TITLE
ADDED: validation for pending assets to cancel vault

### DIFF
--- a/src/modules/vaults/vaults-admin/vaults-admin.service.ts
+++ b/src/modules/vaults/vaults-admin/vaults-admin.service.ts
@@ -8,6 +8,7 @@ import { Vault } from '@/database/vault.entity';
 import { ClaimsService } from '@/modules/vaults/claims/claims.service';
 import { PaginatedResponseDto } from '@/modules/vaults/dto/paginated-response.dto';
 import { VaultManagingService } from '@/modules/vaults/processing-tx/onchain/vault-managing.service';
+import { AssetStatus } from '@/types/asset.types';
 import { TransactionStatus, TransactionType } from '@/types/transaction.types';
 import {
   SmartContractVaultStatus,
@@ -41,7 +42,7 @@ export class VaultsAdminService {
 
     const queryBuilder = this.vaultsRepository
       .createQueryBuilder('vault')
-      .leftJoinAndSelect('vault.owner', 'owner')
+      .innerJoinAndSelect('vault.owner', 'owner')
       .where('vault.deleted = false')
       .andWhere(
         new Brackets(qb => {
@@ -64,8 +65,16 @@ export class VaultsAdminService {
           FROM assets asset
           WHERE asset.vault_id = vault.id
             AND asset.deleted = false
-            AND (asset.added_by IS NULL OR asset.added_by != owner.id)
-        )`
+            AND (
+              asset.status = :pendingAssetStatus
+              OR asset.added_by IS NULL
+              OR (
+                vault.owner_id IS NOT NULL
+                AND asset.added_by <> vault.owner_id
+              )
+            )
+        )`,
+        { pendingAssetStatus: AssetStatus.PENDING }
       );
 
     if (search?.trim()) {
@@ -151,14 +160,20 @@ export class VaultsAdminService {
       return false;
     }
 
-    const hasForeignAssets = await this.assetsRepository
+    const hasBlockingAsset = await this.assetsRepository
       .createQueryBuilder('asset')
       .where('asset.vault_id = :vaultId', { vaultId: vault.id })
       .andWhere('asset.deleted = false')
-      .andWhere('(asset.added_by IS NULL OR asset.added_by != :ownerId)', { ownerId })
+      .andWhere(
+        new Brackets(qb => {
+          qb.where('asset.status = :status', { status: AssetStatus.PENDING })
+            .orWhere('asset.added_by IS NULL')
+            .orWhere('asset.added_by != :ownerId', { ownerId });
+        })
+      )
       .getExists();
 
-    return !hasForeignAssets;
+    return !hasBlockingAsset;
   }
 
   private async getVaultToCancelByIdByAdmin(vaultId: string): Promise<Vault> {

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -2166,13 +2166,24 @@ export class VaultsService {
       }
     }
 
-    const hasForeignAssets = await this.assetsRepository
+    const blockingAsset = await this.assetsRepository
       .createQueryBuilder('asset')
       .where('asset.vault_id = :vaultId', { vaultId })
       .andWhere('asset.deleted = false')
-      .andWhere('(asset.added_by IS NULL OR asset.added_by != :ownerId)', { ownerId })
-      .getExists();
-    if (hasForeignAssets) {
+      .andWhere(
+        new Brackets(qb => {
+          qb.where('asset.status = :status', { status: AssetStatus.PENDING })
+            .orWhere('asset.added_by IS NULL')
+            .orWhere('asset.added_by != :ownerId', { ownerId });
+        })
+      )
+      .getOne();
+
+    if (blockingAsset) {
+      if (blockingAsset.status === AssetStatus.PENDING) {
+        throw new BadRequestException('Vault cannot be cancelled because it has pending assets');
+      }
+
       throw new BadRequestException('Vault cannot be cancelled because it already contains assets from other users');
     }
 


### PR DESCRIPTION
This pull request updates the logic for checking whether a vault can be cancelled, both in the admin and user-facing services. The main improvement is a more robust check for "blocking" assets: assets that are either pending or not owned by the vault owner. This ensures that vaults cannot be cancelled if they contain such assets, and provides more specific error messages.

**Asset blocking logic improvements:**

* Updated the asset check in both `VaultsAdminService` and `VaultsService` to consider assets with `status = PENDING`, assets not added by the owner, or assets with no `added_by` as "blocking" for vault cancellation. This replaces the previous logic that only checked for assets not added by the owner. [[1]](diffhunk://#diff-0cd752fb832153671e3b4979cc9f0a5ba6e9a1fd2115085252b26a22018fa0feL67-R74) [[2]](diffhunk://#diff-0cd752fb832153671e3b4979cc9f0a5ba6e9a1fd2115085252b26a22018fa0feL154-R173) [[3]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L2169-R2186)
* In `VaultsService`, added more specific error messages: if a blocking asset is found and its status is `PENDING`, the error message indicates pending assets; otherwise, it indicates assets from other users.

**Type and import updates:**

* Imported `AssetStatus` in `vaults-admin.service.ts` to support the new asset status check.