### PR TITLE
Include VaultStatus.expansion in vault status filter

### DIFF
--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -1303,7 +1303,7 @@ export class TaptoolsService {
       const allRelevantVaults = await this.vaultRepository.find({
         where: {
           deleted: false,
-          vault_status: In([VaultStatus.contribution, VaultStatus.acquire, VaultStatus.locked]),
+          vault_status: In([VaultStatus.contribution, VaultStatus.acquire, VaultStatus.locked, VaultStatus.expansion]),
         },
         relations: ['owner'],
         select: ['id', 'vault_status', 'ft_token_supply', 'ft_token_decimals', 'initial_total_value_ada', 'owner'],


### PR DESCRIPTION
This pull request makes a minor update to the `TaptoolsService` by including the `VaultStatus.expansion` status in the list of relevant vault statuses when querying the vault repository. This ensures that vaults with the `expansion` status are now considered in the results.