### PR TITLE
Feature/add expandable vault flag

### DIFF
--- a/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
+++ b/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
@@ -18,6 +18,8 @@ export class AddIsExpandableAndAssetWhitelistProposalType1778752796390 implement
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // Delete any proposals with the new proposal type before rolling back the enum
+    await queryRunner.query(`DELETE FROM "proposal" WHERE "proposal_type" = 'asset_whitelist_update'`);
     await queryRunner.query(
       `CREATE TYPE "public"."proposal_proposal_type_enum_old" AS ENUM('staking', 'distribution', 'termination', 'burning', 'buy_sell', 'marketplace_action', 'expansion')`
     );

--- a/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
+++ b/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIsExpandableAndAssetWhitelistProposalType1778752796390 implements MigrationInterface {
+  name = 'AddIsExpandableAndAssetWhitelistProposalType1778752796390';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "vaults" ADD "is_expandable" boolean NOT NULL DEFAULT false`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."proposal_proposal_type_enum" RENAME TO "proposal_proposal_type_enum_old"`
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."proposal_proposal_type_enum" AS ENUM('staking', 'distribution', 'termination', 'burning', 'buy_sell', 'marketplace_action', 'expansion', 'asset_whitelist_update')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "proposal" ALTER COLUMN "proposal_type" TYPE "public"."proposal_proposal_type_enum" USING "proposal_type"::"text"::"public"."proposal_proposal_type_enum"`
+    );
+    await queryRunner.query(`DROP TYPE "public"."proposal_proposal_type_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."proposal_proposal_type_enum_old" AS ENUM('staking', 'distribution', 'termination', 'burning', 'buy_sell', 'marketplace_action', 'expansion')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "proposal" ALTER COLUMN "proposal_type" TYPE "public"."proposal_proposal_type_enum_old" USING "proposal_type"::"text"::"public"."proposal_proposal_type_enum_old"`
+    );
+    await queryRunner.query(`DROP TYPE "public"."proposal_proposal_type_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."proposal_proposal_type_enum_old" RENAME TO "proposal_proposal_type_enum"`
+    );
+    await queryRunner.query(`ALTER TABLE "vaults" DROP COLUMN "is_expandable"`);
+  }
+}

--- a/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
+++ b/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
@@ -9,7 +9,7 @@ export class AddIsExpandableAndAssetWhitelistProposalType1778752796390 implement
       `ALTER TYPE "public"."proposal_proposal_type_enum" RENAME TO "proposal_proposal_type_enum_old"`
     );
     await queryRunner.query(
-      `CREATE TYPE "public"."proposal_proposal_type_enum" AS ENUM('staking', 'distribution', 'termination', 'burning', 'buy_sell', 'marketplace_action', 'expansion', 'asset_whitelist_update')`
+      `CREATE TYPE "public"."proposal_proposal_type_enum" AS ENUM('staking', 'distribution', 'termination', 'burning', 'buy_sell', 'marketplace_action', 'expansion', 'acquire_expansion', 'asset_whitelist_update')`
     );
     await queryRunner.query(
       `ALTER TABLE "proposal" ALTER COLUMN "proposal_type" TYPE "public"."proposal_proposal_type_enum" USING "proposal_type"::"text"::"public"."proposal_proposal_type_enum"`
@@ -21,7 +21,7 @@ export class AddIsExpandableAndAssetWhitelistProposalType1778752796390 implement
     // Delete any proposals with the new proposal type before rolling back the enum
     await queryRunner.query(`DELETE FROM "proposal" WHERE "proposal_type" = 'asset_whitelist_update'`);
     await queryRunner.query(
-      `CREATE TYPE "public"."proposal_proposal_type_enum_old" AS ENUM('staking', 'distribution', 'termination', 'burning', 'buy_sell', 'marketplace_action', 'expansion')`
+      `CREATE TYPE "public"."proposal_proposal_type_enum_old" AS ENUM('staking', 'distribution', 'termination', 'burning', 'buy_sell', 'marketplace_action', 'expansion', 'acquire_expansion')`
     );
     await queryRunner.query(
       `ALTER TABLE "proposal" ALTER COLUMN "proposal_type" TYPE "public"."proposal_proposal_type_enum_old" USING "proposal_type"::"text"::"public"."proposal_proposal_type_enum_old"`

--- a/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
+++ b/src/database/migrations/1778752796390-AddIsExpandableAndAssetWhitelistProposalType.ts
@@ -4,7 +4,7 @@ export class AddIsExpandableAndAssetWhitelistProposalType1778752796390 implement
   name = 'AddIsExpandableAndAssetWhitelistProposalType1778752796390';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "vaults" ADD "is_expandable" boolean NOT NULL DEFAULT false`);
+    await queryRunner.query(`ALTER TABLE "vaults" ADD "is_expandable_asset_whitelist" boolean NOT NULL DEFAULT false`);
     await queryRunner.query(
       `ALTER TYPE "public"."proposal_proposal_type_enum" RENAME TO "proposal_proposal_type_enum_old"`
     );
@@ -30,6 +30,6 @@ export class AddIsExpandableAndAssetWhitelistProposalType1778752796390 implement
     await queryRunner.query(
       `ALTER TYPE "public"."proposal_proposal_type_enum_old" RENAME TO "proposal_proposal_type_enum"`
     );
-    await queryRunner.query(`ALTER TABLE "vaults" DROP COLUMN "is_expandable"`);
+    await queryRunner.query(`ALTER TABLE "vaults" DROP COLUMN "is_expandable_asset_whitelist"`);
   }
 }

--- a/src/database/proposal.entity.ts
+++ b/src/database/proposal.entity.ts
@@ -107,6 +107,16 @@ export class Proposal {
       currentAssetCount?: number; // Track progress
     };
 
+    // Asset whitelist update data
+    assetsWhitelist?: Array<{
+      policyId: string;
+      assetName?: string;
+      collectionName?: string | null;
+      valuationMethod?: string;
+      customPriceAda?: number | null;
+      lpPoolOnchainId?: string | null;
+    }>;
+
     // Swap execution results (for DexHunter swaps)
     swapResults?: Array<{
       assetId: string;

--- a/src/database/vault.entity.ts
+++ b/src/database/vault.entity.ts
@@ -733,9 +733,9 @@ export class Vault {
   @Column({ name: 'deleted', type: 'boolean', nullable: false, default: false })
   deleted: boolean;
 
-  @Expose({ name: 'isExpandable' })
-  @Column({ name: 'is_expandable', type: 'boolean', nullable: false, default: false })
-  is_expandable: boolean;
+  @Expose({ name: 'isExpandableAssetWhitelist' })
+  @Column({ name: 'is_expandable_asset_whitelist', type: 'boolean', nullable: false, default: false })
+  is_expandable_asset_whitelist: boolean;
 
   @Expose({ name: 'governancePhaseStart' })
   @Column({ name: 'governance_phase_start', type: 'timestamptz', nullable: true })

--- a/src/database/vault.entity.ts
+++ b/src/database/vault.entity.ts
@@ -733,6 +733,10 @@ export class Vault {
   @Column({ name: 'deleted', type: 'boolean', nullable: false, default: false })
   deleted: boolean;
 
+  @Expose({ name: 'isExpandable' })
+  @Column({ name: 'is_expandable', type: 'boolean', nullable: false, default: false })
+  is_expandable: boolean;
+
   @Expose({ name: 'governancePhaseStart' })
   @Column({ name: 'governance_phase_start', type: 'timestamptz', nullable: true })
   governance_phase_start?: Date;

--- a/src/modules/distribution/builders/acquire-only-extraction.builder.ts
+++ b/src/modules/distribution/builders/acquire-only-extraction.builder.ts
@@ -132,8 +132,7 @@ export class AcquireOnlyExtractionBuilder {
     });
 
     // ADA goes to admin (LP portion) and treasury (remainder)
-    const lpAdaLovelace =
-      config.lpPercent > 0 ? Math.floor(totalTreasuryLovelace * (config.lpPercent / 200)) : 0;
+    const lpAdaLovelace = config.lpPercent > 0 ? Math.floor(totalTreasuryLovelace * (config.lpPercent / 200)) : 0;
     const netTreasuryLovelace = totalTreasuryLovelace - lpAdaLovelace;
 
     if (lpAdaLovelace > 0) {

--- a/src/modules/globals/system-settings/system-settings.service.ts
+++ b/src/modules/globals/system-settings/system-settings.service.ts
@@ -30,6 +30,7 @@ export interface SystemSettingsData {
   governance_fee_proposal_burning: number;
   governance_fee_proposal_marketplace_action: number;
   governance_fee_proposal_expansion: number;
+  governance_fee_proposal_asset_whitelist_update: number;
   governance_fee_voting: number; // Fee per vote
   // Voting duration constraints (in milliseconds)
   min_voting_duration: number;
@@ -60,6 +61,7 @@ const DEFAULT_SETTINGS: SystemSettingsData = {
   governance_fee_proposal_burning: 3000000, // 3 ADA
   governance_fee_proposal_marketplace_action: 5000000, // 5 ADA
   governance_fee_proposal_expansion: 10000000, // 10 ADA
+  governance_fee_proposal_asset_whitelist_update: 5000000, // 5 ADA
   governance_fee_voting: 0, // No voting fee by default
   // Voting duration constraints (in milliseconds)
   min_voting_duration: 86400000, // 24 hours in ms
@@ -218,6 +220,10 @@ export class SystemSettingsService implements OnModuleInit {
     return this.settings.governance_fee_proposal_expansion || 0;
   }
 
+  get governanceFeeProposalAssetWhitelistUpdate(): number {
+    return this.settings.governance_fee_proposal_asset_whitelist_update || 0;
+  }
+
   get governanceFeeVoting(): number {
     return this.settings.governance_fee_voting || 0;
   }
@@ -268,6 +274,8 @@ export class SystemSettingsService implements OnModuleInit {
         return this.governanceFeeProposalMarketplaceAction;
       case 'expansion':
         return this.governanceFeeProposalExpansion;
+      case 'asset_whitelist_update':
+        return this.governanceFeeProposalAssetWhitelistUpdate;
       default:
         this.logger.warn(`Unknown proposal type: "${proposalType}" - returning 0`);
         return 0;

--- a/src/modules/vaults/draft-vaults.service.ts
+++ b/src/modules/vaults/draft-vaults.service.ts
@@ -120,8 +120,8 @@ export class DraftVaultsService {
     const plain = classToPlain(vault) as Record<string, unknown>;
     plain.tokenDescription = plain.token_description;
     delete plain.token_description;
-    plain.isExpandable = vault.is_expandable;
-    delete plain.is_expandable;
+    plain.isExpandableAssetWhitelist = vault.is_expandable_asset_whitelist;
+    delete plain.is_expandable_asset_whitelist;
     plain.tags = vault.tags?.map(t => t.name) ?? [];
 
     // todo need to create additional model for remove owner, and transform image to link
@@ -232,7 +232,8 @@ export class DraftVaultsService {
       if (data.executionThreshold) vaultData.execution_threshold = data.executionThreshold;
       if (data.cosigningThreshold) vaultData.cosigning_threshold = data.cosigningThreshold;
       if (data.vaultAppreciation) vaultData.vault_appreciation = data.vaultAppreciation;
-      if (data.isExpandable !== undefined) vaultData.is_expandable = data.isExpandable;
+      if (data.isExpandableAssetWhitelist !== undefined)
+        vaultData.is_expandable_asset_whitelist = data.isExpandableAssetWhitelist;
 
       if (data.contributionDuration !== undefined) {
         vaultData.contribution_duration = data.contributionDuration;

--- a/src/modules/vaults/draft-vaults.service.ts
+++ b/src/modules/vaults/draft-vaults.service.ts
@@ -120,6 +120,8 @@ export class DraftVaultsService {
     const plain = classToPlain(vault) as Record<string, unknown>;
     plain.tokenDescription = plain.token_description;
     delete plain.token_description;
+    plain.isExpandable = vault.is_expandable;
+    delete plain.is_expandable;
     plain.tags = vault.tags?.map(t => t.name) ?? [];
 
     // todo need to create additional model for remove owner, and transform image to link
@@ -230,6 +232,7 @@ export class DraftVaultsService {
       if (data.executionThreshold) vaultData.execution_threshold = data.executionThreshold;
       if (data.cosigningThreshold) vaultData.cosigning_threshold = data.cosigningThreshold;
       if (data.vaultAppreciation) vaultData.vault_appreciation = data.vaultAppreciation;
+      if (data.isExpandable !== undefined) vaultData.is_expandable = data.isExpandable;
 
       if (data.contributionDuration !== undefined) {
         vaultData.contribution_duration = data.contributionDuration;

--- a/src/modules/vaults/dto/createVault.req.ts
+++ b/src/modules/vaults/dto/createVault.req.ts
@@ -422,5 +422,5 @@ export class CreateVaultReq {
   @IsOptional()
   @IsBoolean()
   @Expose()
-  isExpandable?: boolean;
+  isExpandableAssetWhitelist?: boolean;
 }

--- a/src/modules/vaults/dto/createVault.req.ts
+++ b/src/modules/vaults/dto/createVault.req.ts
@@ -4,6 +4,7 @@ import {
   ArrayMaxSize,
   ArrayNotEmpty,
   IsArray,
+  IsBoolean,
   IsEnum,
   IsNotEmpty,
   IsNumber,
@@ -412,4 +413,14 @@ export class CreateVaultReq {
   @IsString({ each: true })
   @Expose()
   tags?: string[];
+
+  @ApiProperty({
+    description: 'Whether the vault whitelist supports expansion',
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Expose()
+  isExpandable?: boolean;
 }

--- a/src/modules/vaults/dto/createVault.req.ts
+++ b/src/modules/vaults/dto/createVault.req.ts
@@ -18,7 +18,6 @@ import {
   ValidateIf,
   ArrayMinSize,
   IsUUID,
-  IsBoolean,
 } from 'class-validator';
 
 import { AcquirerWhitelist, ContributorWhitelist, SocialLink, AcquirerWhitelistCsv } from '../types';

--- a/src/modules/vaults/dto/saveDraft.req.ts
+++ b/src/modules/vaults/dto/saveDraft.req.ts
@@ -419,7 +419,7 @@ export class SaveDraftReq {
   tags?: string[] | null;
 
   @ApiProperty({
-    description: 'Whether the vault supports expansion',
+    description: 'Whether the vault supports asset whitelist expansion',
     required: false,
     nullable: true,
     default: false,

--- a/src/modules/vaults/dto/saveDraft.req.ts
+++ b/src/modules/vaults/dto/saveDraft.req.ts
@@ -428,5 +428,5 @@ export class SaveDraftReq {
   @ValidateIf((o, v) => v !== null)
   @IsBoolean()
   @Expose()
-  isExpandable?: boolean | null;
+  isExpandableAssetWhitelist?: boolean | null;
 }

--- a/src/modules/vaults/dto/saveDraft.req.ts
+++ b/src/modules/vaults/dto/saveDraft.req.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import {
   IsArray,
+  IsBoolean,
   IsEnum,
   IsNumber,
   IsOptional,
@@ -416,4 +417,16 @@ export class SaveDraftReq {
   @IsString({ each: true })
   @Expose()
   tags?: string[] | null;
+
+  @ApiProperty({
+    description: 'Whether the vault supports expansion',
+    required: false,
+    nullable: true,
+    default: false,
+  })
+  @IsOptional()
+  @ValidateIf((o, v) => v !== null)
+  @IsBoolean()
+  @Expose()
+  isExpandable?: boolean | null;
 }

--- a/src/modules/vaults/dto/vault.response.ts
+++ b/src/modules/vaults/dto/vault.response.ts
@@ -786,6 +786,13 @@ export class VaultFullResponse extends VaultShortResponse {
   })
   expansionLimitPrice?: number;
 
+  @ApiProperty({ description: 'Whether the vault supports expansion', required: false })
+  @DtoRepresent({
+    transform: false,
+    expose: { name: 'isExpandable' },
+  })
+  isExpandable?: boolean;
+
   @ApiProperty({ description: 'Owner of the vault', type: () => User })
   @DtoRepresent({
     transform: false,

--- a/src/modules/vaults/dto/vault.response.ts
+++ b/src/modules/vaults/dto/vault.response.ts
@@ -786,12 +786,12 @@ export class VaultFullResponse extends VaultShortResponse {
   })
   expansionLimitPrice?: number;
 
-  @ApiProperty({ description: 'Whether the vault supports expansion', required: false })
+  @ApiProperty({ description: 'Whether the vault supports asset whitelist expansion', required: false })
   @DtoRepresent({
     transform: false,
-    expose: { name: 'isExpandable' },
+    expose: { name: 'isExpandableAssetWhitelist' },
   })
-  isExpandable?: boolean;
+  isExpandableAssetWhitelist?: boolean;
 
   @ApiProperty({ description: 'Owner of the vault', type: () => User })
   @DtoRepresent({

--- a/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
+++ b/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, OmitType } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import {
   IsNotEmpty,
@@ -11,8 +11,11 @@ import {
   IsNumber,
   IsNumberString,
   Matches,
+  ArrayMinSize,
+  ValidateIf,
 } from 'class-validator';
 
+import { AssetWhitelistDto } from '@/modules/vaults/dto/assetWhitelist.dto';
 import { MarketplaceAction, ProposalType } from '@/types/proposal.types';
 
 // Common FT asset class for staking
@@ -278,6 +281,8 @@ export class ExpansionPolicyIdDto {
   label?: string;
 }
 
+export class AssetWhitelistProposalDto extends OmitType(AssetWhitelistDto, ['countCapMin', 'countCapMax'] as const) {}
+
 export class CreateProposalReq {
   @ApiProperty({
     description: 'Title of the proposal',
@@ -455,6 +460,19 @@ export class CreateProposalReq {
   @IsNumber()
   @Expose()
   expansionLimitPrice?: number;
+
+  @ApiProperty({
+    description: 'Assets to add to the vault whitelist for asset whitelist update proposals',
+    type: [AssetWhitelistProposalDto],
+    required: false,
+  })
+  @ValidateIf(o => o.type === ProposalType.ASSET_WHITELIST_UPDATE)
+  @IsArray()
+  @ArrayMinSize(1, { message: 'At least one asset must be provided for asset whitelist update proposals' })
+  @ValidateNested({ each: true })
+  @Type(() => AssetWhitelistProposalDto)
+  @Expose()
+  assetsWhitelist?: AssetWhitelistProposalDto[];
 
   @ApiProperty({
     description: 'Additional metadata for the proposal',

--- a/src/modules/vaults/phase-management/governance/dto/governance-fee.dto.ts
+++ b/src/modules/vaults/phase-management/governance/dto/governance-fee.dto.ts
@@ -49,6 +49,13 @@ export class GetGovernanceFeesRes {
   proposalFeeExpansion: number;
 
   @ApiProperty({
+    description: 'Governance fee for asset whitelist update proposals (in lovelace)',
+    example: 5000000,
+  })
+  @Expose()
+  proposalFeeAssetWhitelistUpdate: number;
+
+  @ApiProperty({
     description: 'Governance fee for voting (in lovelace)',
     example: 0,
   })

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -2182,13 +2182,6 @@ export class GovernanceExecutionService {
         }
       );
 
-      this.eventEmitter.emit('proposal.asset-whitelist-update.executed', {
-        proposalId: proposal.id,
-        vaultId: proposal.vaultId,
-        insertedCount,
-        onChainTxHash: onChainResult.txHash,
-      });
-
       return true;
     } catch (error) {
       await this.storeExecutionError(proposal, error);

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -15,6 +15,7 @@ import { TerminationService } from './termination.service';
 import { VoteCountingService } from './vote-counting.service';
 
 import { Asset } from '@/database/asset.entity';
+import { AssetsWhitelistEntity } from '@/database/assetsWhitelist.entity';
 import { Claim } from '@/database/claim.entity';
 import { Proposal } from '@/database/proposal.entity';
 import { Vault } from '@/database/vault.entity';
@@ -22,6 +23,7 @@ import { DexHunterService } from '@/modules/dexhunter/dexhunter.service';
 import { RewardEventProducer } from '@/modules/rewards/services/reward-event-producer.service';
 import { AssetsService } from '@/modules/vaults/assets/assets.service';
 import { TransactionsService } from '@/modules/vaults/processing-tx/offchain-tx/transactions.service';
+import { VaultManagingService } from '@/modules/vaults/processing-tx/onchain/vault-managing.service';
 import { TreasuryWalletService } from '@/modules/vaults/treasure/treasure-wallet.service';
 import { TreasuryExtractionService } from '@/modules/vaults/treasure/treasury-extraction.service';
 import { WayUpPricingService } from '@/modules/wayup/wayup-pricing.service';
@@ -31,7 +33,7 @@ import { ClaimType } from '@/types/claim.types';
 import { ProposalStatus, ProposalType } from '@/types/proposal.types';
 import { RewardActivityType } from '@/types/rewards.types';
 import { TransactionStatus } from '@/types/transaction.types';
-import { VaultStatus } from '@/types/vault.types';
+import { VaultStatus, SmartContractVaultStatus } from '@/types/vault.types';
 
 @Injectable()
 export class GovernanceExecutionService {
@@ -56,6 +58,8 @@ export class GovernanceExecutionService {
     private readonly assetRepository: Repository<Asset>,
     @InjectRepository(Vault)
     private readonly vaultRepository: Repository<Vault>,
+    @InjectRepository(AssetsWhitelistEntity)
+    private readonly assetsWhitelistRepository: Repository<AssetsWhitelistEntity>,
     private readonly eventEmitter: EventEmitter2,
     private readonly assetsService: AssetsService,
     private readonly wayUpService: WayUpService,
@@ -68,6 +72,7 @@ export class GovernanceExecutionService {
     private readonly distributionService: DistributionService,
     private readonly dexHunterService: DexHunterService,
     private readonly expansionService: ExpansionService,
+    private readonly vaultManagingService: VaultManagingService,
     private readonly wayUpPricingService: WayUpPricingService,
     private readonly treasuryWalletService: TreasuryWalletService,
     private readonly governanceRefundService: GovernanceRefundService,
@@ -657,6 +662,9 @@ export class GovernanceExecutionService {
 
         case ProposalType.EXPANSION:
           return await this.executeExpansionProposal(proposal);
+
+        case ProposalType.ASSET_WHITELIST_UPDATE:
+          return await this.executeAssetWhitelistUpdateProposal(proposal);
 
         default:
           this.logger.warn(`Unknown proposal type: ${proposal.proposalType}`);
@@ -2046,6 +2054,85 @@ export class GovernanceExecutionService {
   async executeExpansionProposal(proposal: Proposal): Promise<boolean> {
     try {
       return await this.expansionService.executeExpansion(proposal);
+    } catch (error) {
+      await this.storeExecutionError(proposal, error);
+      throw error;
+    }
+  }
+
+  async executeAssetWhitelistUpdateProposal(proposal: Proposal): Promise<boolean> {
+    const whitelistItems = proposal.metadata?.assetsWhitelist;
+
+    if (!whitelistItems || whitelistItems.length === 0) {
+      this.logger.warn(`Asset whitelist update proposal ${proposal.id} has no whitelist entries`);
+      return false;
+    }
+
+    try {
+      const vault = await this.vaultRepository.findOne({
+        where: { id: proposal.vaultId },
+        select: [
+          'id',
+          'asset_vault_name',
+          'privacy',
+          'contribution_phase_start',
+          'contribution_duration',
+          'value_method',
+          'vault_sc_status',
+        ],
+      });
+
+      if (!vault) {
+        throw new Error(`Vault ${proposal.vaultId} not found`);
+      }
+
+      let insertedCount = 0;
+
+      for (const item of whitelistItems) {
+        const result = await this.assetsWhitelistRepository
+          .createQueryBuilder()
+          .insert()
+          .values({
+            vault: { id: vault.id },
+            policy_id: item.policyId,
+            collection_name: item.collectionName ?? null,
+            valuation_method: item.valuationMethod || 'market',
+            custom_price_ada: item.customPriceAda ?? null,
+            lp_pool_onchain_id: item.lpPoolOnchainId ?? null,
+          })
+          .orIgnore()
+          .execute();
+
+        if (result.identifiers.length > 0) {
+          insertedCount += 1;
+        }
+      }
+
+      if (insertedCount === 0) {
+        this.logger.warn(`Asset whitelist update proposal ${proposal.id} did not insert any new whitelist entries`);
+        return false;
+      }
+
+      const onChainResult = await this.vaultManagingService.updateVaultMetadataTx({
+        vault,
+        vaultStatus: vault.vault_sc_status || SmartContractVaultStatus.SUCCESSFUL,
+      });
+
+      await this.vaultRepository.update(
+        { id: vault.id },
+        {
+          last_update_tx_hash: onChainResult.txHash,
+        }
+      );
+
+      this.eventEmitter.emit('proposal.asset-whitelist-update.executed', {
+        proposalId: proposal.id,
+        vaultId: proposal.vaultId,
+        insertedCount,
+        onChainTxHash: onChainResult.txHash,
+      });
+
+      return true;
     } catch (error) {
       await this.storeExecutionError(proposal, error);
       throw error;

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -607,19 +607,21 @@ export class GovernanceExecutionService {
       return false;
     }
 
-    // Proposals that involve asset extraction from vault can only execute when vault is LOCKED
+    // Proposals that require vault to be LOCKED can only execute in that status
     // During EXPANSION, assets are being added and extraction would conflict with the expansion mechanics
-    const extractionProposalTypes = [
+    // Asset whitelist updates also require LOCKED status to ensure consistency with vault state
+    const lockedOnlyProposalTypes = [
       ProposalType.MARKETPLACE_ACTION,
       ProposalType.BUY_SELL,
       ProposalType.BURNING,
       ProposalType.TERMINATION,
+      ProposalType.ASSET_WHITELIST_UPDATE,
     ];
 
-    if (extractionProposalTypes.includes(proposal.proposalType)) {
+    if (lockedOnlyProposalTypes.includes(proposal.proposalType)) {
       if (vault.vault_status !== VaultStatus.locked) {
         this.logger.warn(
-          `Cannot execute ${proposal.proposalType} proposal ${proposal.id}: Vault must be in LOCKED status for asset extraction. Current status: ${vault.vault_status}`
+          `Cannot execute ${proposal.proposalType} proposal ${proposal.id}: Vault must be in LOCKED status. Current status: ${vault.vault_status}`
         );
         // Store error in metadata so it can be retried later
         await this.proposalRepository.update(
@@ -632,30 +634,6 @@ export class GovernanceExecutionService {
                 timestamp: new Date().toISOString(),
                 errorCode: 'VAULT_STATUS_NOT_LOCKED',
                 userFriendlyMessage: 'This proposal will automatically retry when vault returns to LOCKED status.',
-              },
-            },
-          }
-        );
-        return false;
-      }
-    }
-
-    if (proposal.proposalType === ProposalType.ASSET_WHITELIST_UPDATE) {
-      if (vault.vault_status !== VaultStatus.locked) {
-        this.logger.warn(
-          `Cannot execute asset whitelist update proposal ${proposal.id}: vault must be LOCKED. Current status: ${vault.vault_status}`
-        );
-        await this.proposalRepository.update(
-          { id: proposal.id },
-          {
-            metadata: {
-              ...proposal.metadata,
-              executionError: {
-                message: `Asset whitelist updates require the vault to be in LOCKED status. Current status: ${vault.vault_status}.`,
-                timestamp: new Date().toISOString(),
-                errorCode: 'VAULT_STATUS_NOT_LOCKED_WHITELIST',
-                userFriendlyMessage:
-                  'This proposal will retry automatically once the vault is back in LOCKED status (for example, after expansion ends).',
               },
             },
           }

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -2106,7 +2106,7 @@ export class GovernanceExecutionService {
         'contribution_duration',
         'value_method',
         'vault_sc_status',
-        'is_expandable',
+        'is_expandable_asset_whitelist',
       ],
     });
 
@@ -2116,7 +2116,7 @@ export class GovernanceExecutionService {
       throw err;
     }
 
-    if (!vault.is_expandable) {
+    if (!vault.is_expandable_asset_whitelist) {
       const err = new Error(
         'This vault is not marked as expandable; asset whitelist update proposals cannot be executed.'
       );

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -640,6 +640,30 @@ export class GovernanceExecutionService {
       }
     }
 
+    if (proposal.proposalType === ProposalType.ASSET_WHITELIST_UPDATE) {
+      if (vault.vault_status !== VaultStatus.locked) {
+        this.logger.warn(
+          `Cannot execute asset whitelist update proposal ${proposal.id}: vault must be LOCKED. Current status: ${vault.vault_status}`
+        );
+        await this.proposalRepository.update(
+          { id: proposal.id },
+          {
+            metadata: {
+              ...proposal.metadata,
+              executionError: {
+                message: `Asset whitelist updates require the vault to be in LOCKED status. Current status: ${vault.vault_status}.`,
+                timestamp: new Date().toISOString(),
+                errorCode: 'VAULT_STATUS_NOT_LOCKED_WHITELIST',
+                userFriendlyMessage:
+                  'This proposal will retry automatically once the vault is back in LOCKED status (for example, after expansion ends).',
+              },
+            },
+          }
+        );
+        return false;
+      }
+    }
+
     try {
       switch (proposal.proposalType) {
         case ProposalType.MARKETPLACE_ACTION:
@@ -2064,30 +2088,45 @@ export class GovernanceExecutionService {
     const whitelistItems = proposal.metadata?.assetsWhitelist;
 
     if (!whitelistItems || whitelistItems.length === 0) {
-      this.logger.warn(`Asset whitelist update proposal ${proposal.id} has no whitelist entries`);
-      return false;
+      const err = new Error(
+        'This proposal has no assetsWhitelist payload in metadata; it cannot be executed as an asset whitelist update.'
+      );
+      this.logger.warn(`Asset whitelist update proposal ${proposal.id} has no whitelist entries in metadata`);
+      await this.storeExecutionError(proposal, err);
+      throw err;
     }
 
+    const vault = await this.vaultRepository.findOne({
+      where: { id: proposal.vaultId },
+      select: [
+        'id',
+        'asset_vault_name',
+        'privacy',
+        'contribution_phase_start',
+        'contribution_duration',
+        'value_method',
+        'vault_sc_status',
+        'is_expandable',
+      ],
+    });
+
+    if (!vault) {
+      const err = new Error(`Vault ${proposal.vaultId} not found`);
+      await this.storeExecutionError(proposal, err);
+      throw err;
+    }
+
+    if (!vault.is_expandable) {
+      const err = new Error(
+        'This vault is not marked as expandable; asset whitelist update proposals cannot be executed.'
+      );
+      await this.storeExecutionError(proposal, err);
+      throw err;
+    }
+
+    let insertedCount = 0;
+
     try {
-      const vault = await this.vaultRepository.findOne({
-        where: { id: proposal.vaultId },
-        select: [
-          'id',
-          'asset_vault_name',
-          'privacy',
-          'contribution_phase_start',
-          'contribution_duration',
-          'value_method',
-          'vault_sc_status',
-        ],
-      });
-
-      if (!vault) {
-        throw new Error(`Vault ${proposal.vaultId} not found`);
-      }
-
-      let insertedCount = 0;
-
       for (const item of whitelistItems) {
         const result = await this.assetsWhitelistRepository
           .createQueryBuilder()
@@ -2107,12 +2146,21 @@ export class GovernanceExecutionService {
           insertedCount += 1;
         }
       }
+    } catch (error) {
+      await this.storeExecutionError(proposal, error);
+      throw error;
+    }
 
-      if (insertedCount === 0) {
-        this.logger.warn(`Asset whitelist update proposal ${proposal.id} did not insert any new whitelist entries`);
-        return false;
-      }
+    if (insertedCount === 0) {
+      const err = new Error(
+        'No new whitelist rows were inserted: every policy in this proposal already exists for this vault (unique vault_id + policy_id).'
+      );
+      this.logger.warn(`Asset whitelist update proposal ${proposal.id} did not insert any new whitelist entries`);
+      await this.storeExecutionError(proposal, err);
+      throw err;
+    }
 
+    try {
       const onChainResult = await this.vaultManagingService.updateVaultMetadataTx({
         vault,
         vaultStatus: vault.vault_sc_status || SmartContractVaultStatus.SUCCESSFUL,
@@ -2186,6 +2234,14 @@ export class GovernanceExecutionService {
    */
   private getUserFriendlyErrorMessage(errorCode: string): string {
     const errorMessages: Record<string, string> = {
+      VAULT_NOT_EXPANDABLE:
+        'This vault does not allow whitelist expansion. Asset whitelist update proposals cannot run on this vault.',
+      WHITELIST_METADATA_MISSING:
+        'This proposal is missing whitelist data in metadata, so it cannot be executed. Recreate the proposal if needed.',
+      WHITELIST_NO_NEW_ENTRIES:
+        'Every policy in this proposal was already on the vault whitelist, so nothing was left to apply.',
+      WHITELIST_DUPLICATE_KEY:
+        'A database constraint blocked a whitelist row (duplicate policy for this vault). Contact support if this persists.',
       INSUFFICIENT_FUNDS: 'Insufficient ADA in treasury to cover transaction fees.',
       ASSET_NOT_AVAILABLE: 'Assets no longer available or already sold.',
       ASSET_ALREADY_LISTED: 'Assets already listed on marketplace. Unlist them first.',
@@ -2212,6 +2268,29 @@ export class GovernanceExecutionService {
   private categorizeError(error: Error): string {
     const errorMessage = error.message || '';
     const errorStack = error.stack || '';
+
+    // Asset whitelist update (execution-time validation)
+    if (errorMessage.includes('has no assetsWhitelist payload')) {
+      return 'WHITELIST_METADATA_MISSING';
+    }
+
+    if (
+      errorMessage.includes('not marked as expandable') ||
+      errorMessage.toLowerCase().includes('whitelist update proposals cannot be executed')
+    ) {
+      return 'VAULT_NOT_EXPANDABLE';
+    }
+
+    if (
+      errorMessage.includes('No new whitelist rows were inserted') ||
+      errorMessage.includes('already exists for this vault')
+    ) {
+      return 'WHITELIST_NO_NEW_ENTRIES';
+    }
+
+    if (errorMessage.includes('23505') || errorMessage.toLowerCase().includes('duplicate key')) {
+      return 'WHITELIST_DUPLICATE_KEY';
+    }
 
     // Insufficient funds errors
     if (

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -2065,6 +2065,11 @@ export class GovernanceExecutionService {
     }
   }
 
+  /**
+   * Execute ASSET_WHITELIST_UPDATE proposal actions
+   * Inserts new policy IDs into the assets_whitelist table for the vault
+   * This is an off-chain only operation - no blockchain transaction is submitted
+   */
   async executeAssetWhitelistUpdateProposal(proposal: Proposal): Promise<boolean> {
     const whitelistItems = proposal.metadata?.assetsWhitelist;
 
@@ -2077,18 +2082,9 @@ export class GovernanceExecutionService {
       throw err;
     }
 
-    const vault = await this.vaultRepository.findOne({
+    const vault: Pick<Vault, 'id' | 'is_expandable_asset_whitelist'> = await this.vaultRepository.findOne({
       where: { id: proposal.vaultId },
-      select: [
-        'id',
-        'asset_vault_name',
-        'privacy',
-        'contribution_phase_start',
-        'contribution_duration',
-        'value_method',
-        'vault_sc_status',
-        'is_expandable_asset_whitelist',
-      ],
+      select: ['id', 'is_expandable_asset_whitelist'],
     });
 
     if (!vault) {
@@ -2106,7 +2102,6 @@ export class GovernanceExecutionService {
     }
 
     let insertedCount = 0;
-    const insertedPolicyIds: string[] = [];
 
     try {
       for (const item of whitelistItems) {
@@ -2126,7 +2121,6 @@ export class GovernanceExecutionService {
 
         if (result.identifiers.length > 0) {
           insertedCount += 1;
-          insertedPolicyIds.push(item.policyId);
         }
       }
     } catch (error) {
@@ -2136,63 +2130,15 @@ export class GovernanceExecutionService {
 
     if (insertedCount === 0) {
       this.logger.warn(
-        `Asset whitelist update proposal ${proposal.id} did not insert any new whitelist entries; proceeding with on-chain metadata update because whitelist rows may already exist`
+        `Asset whitelist update proposal ${proposal.id} did not insert any new whitelist entries (policies may already exist in whitelist)`
+      );
+    } else {
+      this.logger.log(
+        `Asset whitelist update proposal ${proposal.id} successfully inserted ${insertedCount} new policy ID(s) into whitelist`
       );
     }
 
-    let onChainResult: { txHash: string };
-    try {
-      onChainResult = await this.vaultManagingService.updateVaultMetadataTx({
-        vault,
-        vaultStatus: vault.vault_sc_status || SmartContractVaultStatus.SUCCESSFUL,
-      });
-    } catch (error) {
-      await this.rollbackAssetWhitelistInserts(proposal.id, vault.id, insertedPolicyIds);
-      await this.storeExecutionError(proposal, error);
-      throw error;
-    }
-
-    try {
-      await this.vaultRepository.update(
-        { id: vault.id },
-        {
-          last_update_tx_hash: onChainResult.txHash,
-        }
-      );
-
-      return true;
-    } catch (error) {
-      await this.storeExecutionError(proposal, error);
-      throw error;
-    }
-  }
-
-  /**
-   * Removes whitelist rows inserted during a failed asset whitelist update execution
-   * so off-chain state stays aligned when the on-chain metadata update does not complete.
-   */
-  private async rollbackAssetWhitelistInserts(proposalId: string, vaultId: string, policyIds: string[]): Promise<void> {
-    if (policyIds.length === 0) {
-      return;
-    }
-
-    try {
-      const result = await this.assetsWhitelistRepository.delete({
-        vault: { id: vaultId },
-        policy_id: In(policyIds),
-      });
-
-      this.logger.warn(
-        `Rolled back ${result.affected ?? 0} asset whitelist row(s) for vault ${vaultId} ` +
-          `after on-chain update failed for proposal ${proposalId}`
-      );
-    } catch (rollbackError) {
-      this.logger.error(
-        `Failed to roll back asset whitelist rows for proposal ${proposalId} (vault ${vaultId}, policies: ${policyIds.join(', ')}): ` +
-          `${rollbackError instanceof Error ? rollbackError.message : rollbackError}`,
-        rollbackError instanceof Error ? rollbackError.stack : undefined
-      );
-    }
+    return true;
   }
 
   async executeAcquireExpansionProposal(proposal: Proposal): Promise<boolean> {

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -33,7 +33,7 @@ import { ClaimType } from '@/types/claim.types';
 import { ProposalStatus, ProposalType } from '@/types/proposal.types';
 import { RewardActivityType } from '@/types/rewards.types';
 import { TransactionStatus } from '@/types/transaction.types';
-import { VaultStatus, SmartContractVaultStatus } from '@/types/vault.types';
+import { VaultStatus } from '@/types/vault.types';
 
 @Injectable()
 export class GovernanceExecutionService {

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -2125,6 +2125,7 @@ export class GovernanceExecutionService {
     }
 
     let insertedCount = 0;
+    const insertedPolicyIds: string[] = [];
 
     try {
       for (const item of whitelistItems) {
@@ -2144,6 +2145,7 @@ export class GovernanceExecutionService {
 
         if (result.identifiers.length > 0) {
           insertedCount += 1;
+          insertedPolicyIds.push(item.policyId);
         }
       }
     } catch (error) {
@@ -2160,12 +2162,19 @@ export class GovernanceExecutionService {
       throw err;
     }
 
+    let onChainResult: { txHash: string };
     try {
-      const onChainResult = await this.vaultManagingService.updateVaultMetadataTx({
+      onChainResult = await this.vaultManagingService.updateVaultMetadataTx({
         vault,
         vaultStatus: vault.vault_sc_status || SmartContractVaultStatus.SUCCESSFUL,
       });
+    } catch (error) {
+      await this.rollbackAssetWhitelistInserts(proposal.id, vault.id, insertedPolicyIds);
+      await this.storeExecutionError(proposal, error);
+      throw error;
+    }
 
+    try {
       await this.vaultRepository.update(
         { id: vault.id },
         {
@@ -2184,6 +2193,34 @@ export class GovernanceExecutionService {
     } catch (error) {
       await this.storeExecutionError(proposal, error);
       throw error;
+    }
+  }
+
+  /**
+   * Removes whitelist rows inserted during a failed asset whitelist update execution
+   * so off-chain state stays aligned when the on-chain metadata update does not complete.
+   */
+  private async rollbackAssetWhitelistInserts(proposalId: string, vaultId: string, policyIds: string[]): Promise<void> {
+    if (policyIds.length === 0) {
+      return;
+    }
+
+    try {
+      const result = await this.assetsWhitelistRepository.delete({
+        vault: { id: vaultId },
+        policy_id: In(policyIds),
+      });
+
+      this.logger.warn(
+        `Rolled back ${result.affected ?? 0} asset whitelist row(s) for vault ${vaultId} ` +
+          `after on-chain update failed for proposal ${proposalId}`
+      );
+    } catch (rollbackError) {
+      this.logger.error(
+        `Failed to roll back asset whitelist rows for proposal ${proposalId} (vault ${vaultId}, policies: ${policyIds.join(', ')}): ` +
+          `${rollbackError instanceof Error ? rollbackError.message : rollbackError}`,
+        rollbackError instanceof Error ? rollbackError.stack : undefined
+      );
     }
   }
 

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -2154,12 +2154,9 @@ export class GovernanceExecutionService {
     }
 
     if (insertedCount === 0) {
-      const err = new Error(
-        'No new whitelist rows were inserted: every policy in this proposal already exists for this vault (unique vault_id + policy_id).'
+      this.logger.warn(
+        `Asset whitelist update proposal ${proposal.id} did not insert any new whitelist entries; proceeding with on-chain metadata update because whitelist rows may already exist`
       );
-      this.logger.warn(`Asset whitelist update proposal ${proposal.id} did not insert any new whitelist entries`);
-      await this.storeExecutionError(proposal, err);
-      throw err;
     }
 
     let onChainResult: { txHash: string };

--- a/src/modules/vaults/phase-management/governance/governance-fee.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-fee.service.ts
@@ -204,6 +204,7 @@ export class GovernanceFeeService {
       expansion: 'Expansion',
       buy_sell: 'Marketplace Action',
       acquire_expansion: 'Acquire Expansion',
+      asset_whitelist_update: 'Asset Whitelist Update',
     };
     return labels[proposalType] || proposalType;
   }

--- a/src/modules/vaults/phase-management/governance/governance.controller.ts
+++ b/src/modules/vaults/phase-management/governance/governance.controller.ts
@@ -222,6 +222,7 @@ export class GovernanceController {
       proposalFeeBurning: this.governanceFeeService.getProposalFee('burning'),
       proposalFeeMarketplaceAction: this.governanceFeeService.getProposalFee('marketplace_action'),
       proposalFeeExpansion: this.governanceFeeService.getProposalFee('expansion'),
+      proposalFeeAssetWhitelistUpdate: this.governanceFeeService.getProposalFee('asset_whitelist_update'),
       votingFee: this.governanceFeeService.getVotingFee(),
     };
   }

--- a/src/modules/vaults/phase-management/governance/governance.module.ts
+++ b/src/modules/vaults/phase-management/governance/governance.module.ts
@@ -25,6 +25,7 @@ import { AssetsWhitelistEntity } from '@/database/assetsWhitelist.entity';
 import { Claim } from '@/database/claim.entity';
 import { Proposal } from '@/database/proposal.entity';
 import { Snapshot } from '@/database/snapshot.entity';
+import { TokenVerification } from '@/database/token-verification.entity';
 import { Transaction } from '@/database/transaction.entity';
 import { User } from '@/database/user.entity';
 import { Vault } from '@/database/vault.entity';
@@ -54,6 +55,7 @@ import { WayUpModule } from '@/modules/wayup/wayup.module';
       Transaction,
       VaultTreasuryWallet,
       AssetsWhitelistEntity,
+      TokenVerification,
     ]),
     RedisModule,
     AssetsModule,

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -420,11 +420,13 @@ export class GovernanceService {
       );
     }
 
-    const vault: Pick<Vault, 'id' | 'vault_status' | 'script_hash' | 'asset_vault_name' | 'name' | 'assets_whitelist' | 'is_expandable'> =
-      await this.vaultRepository.findOne({
-        where: { id: vaultId },
-        select: ['id', 'vault_status', 'script_hash', 'asset_vault_name', 'name', 'assets_whitelist', 'is_expandable'],
-      });
+    const vault: Pick<
+      Vault,
+      'id' | 'vault_status' | 'script_hash' | 'asset_vault_name' | 'name' | 'assets_whitelist' | 'is_expandable'
+    > = await this.vaultRepository.findOne({
+      where: { id: vaultId },
+      select: ['id', 'vault_status', 'script_hash', 'asset_vault_name', 'name', 'assets_whitelist', 'is_expandable'],
+    });
 
     if (!vault) {
       throw new NotFoundException('Vault not found');
@@ -492,6 +494,23 @@ export class GovernanceService {
         throw new BadRequestException(
           `Only one expansion proposal can be active at a time. ` +
             `Please wait for the current expansion proposal "${activeExpansionProposal.title}" to complete before creating a new one.`
+        );
+      }
+    }
+
+    if (createProposalReq.type === ProposalType.ASSET_WHITELIST_UPDATE) {
+      const activeAssetWhitelistProposal = await this.proposalRepository.findOne({
+        where: {
+          vaultId,
+          proposalType: ProposalType.ASSET_WHITELIST_UPDATE,
+          status: In([ProposalStatus.ACTIVE, ProposalStatus.UPCOMING]),
+        },
+      });
+
+      if (activeAssetWhitelistProposal) {
+        throw new BadRequestException(
+          `Only one asset whitelist update proposal can be active at a time. ` +
+            `Please wait for the current proposal "${activeAssetWhitelistProposal.title}" to complete before creating a new one.`
         );
       }
     }

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -3187,7 +3187,10 @@ export class GovernanceService {
     }
 
     if (unverifiedPolicyIds.length > 0) {
-      throw new BadRequestException(`All whitelist tokens must be verified.`);
+      const uniquePolicyIds = [...new Set(unverifiedPolicyIds)];
+      throw new BadRequestException(
+        `All whitelist tokens must be verified. Unverified policy IDs: ${uniquePolicyIds.join(', ')}.`
+      );
     }
   }
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -1,4 +1,4 @@
-﻿import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
+import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
 import {
   BadRequestException,
   ForbiddenException,
@@ -36,6 +36,7 @@ import { AssetsWhitelistEntity } from '@/database/assetsWhitelist.entity';
 import { Claim } from '@/database/claim.entity';
 import { Proposal } from '@/database/proposal.entity';
 import { Snapshot } from '@/database/snapshot.entity';
+import { TokenVerification } from '@/database/token-verification.entity';
 import { User } from '@/database/user.entity';
 import { Vault } from '@/database/vault.entity';
 import { Vote } from '@/database/vote.entity';
@@ -47,7 +48,7 @@ import { TaptoolsService } from '@/modules/taptools/taptools.service';
 import { GetAssetsToListRes } from '@/modules/vaults/phase-management/governance/dto/get-assets-to-list.res';
 import { TreasuryWalletService } from '@/modules/vaults/treasure/treasure-wallet.service';
 import { WayUpPricingService } from '@/modules/wayup/wayup-pricing.service';
-import { AssetOriginType, AssetStatus, AssetType } from '@/types/asset.types';
+import { AssetOriginType, AssetStatus, AssetType, AssetValuationMethod } from '@/types/asset.types';
 import { ClaimStatus, ClaimType } from '@/types/claim.types';
 import { ProposalStatus, ProposalType } from '@/types/proposal.types';
 import { RewardActivityType } from '@/types/rewards.types';
@@ -118,6 +119,8 @@ export class GovernanceService {
     private readonly assetRepository: Repository<Asset>,
     @InjectRepository(AssetsWhitelistEntity)
     private readonly assetsWhitelistRepository: Repository<AssetsWhitelistEntity>,
+    @InjectRepository(TokenVerification)
+    private readonly tokenVerificationRepository: Repository<TokenVerification>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     private readonly configService: ConfigService,
@@ -417,10 +420,10 @@ export class GovernanceService {
       );
     }
 
-    const vault: Pick<Vault, 'id' | 'vault_status' | 'script_hash' | 'asset_vault_name' | 'name' | 'assets_whitelist'> =
+    const vault: Pick<Vault, 'id' | 'vault_status' | 'script_hash' | 'asset_vault_name' | 'name' | 'assets_whitelist' | 'is_expandable'> =
       await this.vaultRepository.findOne({
         where: { id: vaultId },
-        select: ['id', 'vault_status', 'script_hash', 'asset_vault_name', 'name', 'assets_whitelist'],
+        select: ['id', 'vault_status', 'script_hash', 'asset_vault_name', 'name', 'assets_whitelist', 'is_expandable'],
       });
 
     if (!vault) {
@@ -1329,6 +1332,97 @@ export class GovernanceService {
           limitPrice: expansionPriceType === 'limit' ? expansionLimitPrice : undefined,
           currentAssetCount: 0,
         };
+
+        break;
+      }
+
+      case ProposalType.ASSET_WHITELIST_UPDATE: {
+        if (!vault.is_expandable) {
+          throw new BadRequestException(
+            'This vault does not allow expanding the asset whitelist. Only vaults marked as expandable can create asset whitelist update proposals.'
+          );
+        }
+
+        const assetsWhitelist = createProposalReq.assetsWhitelist || [];
+
+        if (assetsWhitelist.length === 0) {
+          throw new BadRequestException(
+            'Provide at least one asset to add. Asset whitelist update proposals require a non-empty assetsWhitelist array.'
+          );
+        }
+
+        const uniqueWhitelistItems = Array.from(
+          new Map(assetsWhitelist.map(item => [`${item.policyId}:${item.assetName || ''}`, item])).values()
+        );
+
+        const existingWhitelist = await this.assetsWhitelistRepository.find({
+          where: { vault: { id: vaultId } },
+          select: ['policy_id'],
+        });
+
+        if (existingWhitelist.length + uniqueWhitelistItems.length > 30) {
+          throw new BadRequestException(
+            `The vault whitelist cannot exceed 30 policies in total. This vault already has ${existingWhitelist.length}, and this proposal would add ${uniqueWhitelistItems.length}.`
+          );
+        }
+
+        const duplicatePolicyIds = uniqueWhitelistItems
+          .map(item => item.policyId)
+          .filter(policyId => existingWhitelist.some(item => item.policy_id === policyId));
+
+        if (duplicatePolicyIds.length > 0) {
+          throw new BadRequestException(
+            `Provided policy IDs are already on this vault's whitelist and cannot be added again.`
+          );
+        }
+
+        await this.ensureAssetWhitelistTokensAreVerified(uniqueWhitelistItems);
+
+        const policyIds = uniqueWhitelistItems.map(item => item.policyId).filter(Boolean);
+        const lpTokensData =
+          policyIds.length > 0
+            ? await this.tokenVerificationRepository.find({
+                where: { policy_id: In(policyIds) },
+                select: ['policy_id', 'lp_pool_onchain_id', 'is_lp_token'],
+              })
+            : [];
+        const lpTokenMap = new Map(
+          lpTokensData.map(lp => [lp.policy_id, { onchainId: lp.lp_pool_onchain_id, isLp: lp.is_lp_token }])
+        );
+
+        for (const assetItem of uniqueWhitelistItems) {
+          const lpData = lpTokenMap.get(assetItem.policyId);
+
+          if (lpData?.isLp) {
+            if (!lpData.onchainId) {
+              throw new BadRequestException(
+                `Policy ${assetItem.policyId} is registered as an LP token but has no lp_pool_onchain_id in token_verifications. ` +
+                  'Add a valid on-chain pool ID for this token before it can be whitelisted.'
+              );
+            }
+            assetItem.valuationMethod = AssetValuationMethod.LP_TOKEN_DYNAMIC;
+          } else if (assetItem.valuationMethod === AssetValuationMethod.LP_TOKEN_DYNAMIC) {
+            throw new BadRequestException(
+              `Policy ${assetItem.policyId} is not an LP token and cannot use the "lp_token_dynamic" valuation method. ` +
+                'Mark it as an LP token in token_verifications, or choose a different valuation method.'
+            );
+          }
+        }
+
+        proposal.metadata.assetsWhitelist = uniqueWhitelistItems.map(assetItem => {
+          const lpData = lpTokenMap.get(assetItem.policyId);
+          const rawFallbackCollectionName = assetItem.collectionName || assetItem.name || assetItem.policyName || null;
+          const fallbackCollectionName = rawFallbackCollectionName ? rawFallbackCollectionName.slice(0, 255) : null;
+
+          return {
+            policyId: assetItem.policyId,
+            assetName: assetItem.assetName,
+            collectionName: fallbackCollectionName,
+            valuationMethod: assetItem.valuationMethod || AssetValuationMethod.MARKET,
+            customPriceAda: assetItem.customPriceAda ?? null,
+            lpPoolOnchainId: lpData?.onchainId || null,
+          };
+        });
 
         break;
       }
@@ -2609,6 +2703,55 @@ export class GovernanceService {
         this.proposalCreationCache.set(cacheKey, false, this.CACHE_TTL.CAN_CREATE_PROPOSAL);
       }
       return false;
+    }
+  }
+
+  private async ensureAssetWhitelistTokensAreVerified(
+    whitelistItems: Array<{ policyId: string; assetName?: string }>
+  ): Promise<void> {
+    if (!this.isMainnet) {
+      return;
+    }
+
+    const unverifiedPolicyIds: string[] = [];
+
+    await Promise.all(
+      whitelistItems.map(async item => {
+        const existing = await this.tokenVerificationRepository.findOne({
+          where: { policy_id: item.policyId },
+          order: { updated_at: 'DESC' },
+        });
+
+        if (existing?.is_verified) {
+          return;
+        }
+
+        const tokenId = `${item.policyId}${item.assetName || ''}`;
+        const dexHunterData = await this.dexHunterService.fetchTokenVerification(tokenId);
+        if (dexHunterData?.isVerified) {
+          return;
+        }
+
+        try {
+          const wayupResponse = await this.wayUpPricingService.getCollectionAssets({ policyId: item.policyId });
+          const firstAsset = wayupResponse.results?.[0];
+          const hasResults = Array.isArray(wayupResponse.results) && wayupResponse.results.length > 0;
+
+          if (hasResults && firstAsset?.collection?.verified) {
+            return;
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Failed to verify whitelist token ${item.policyId}: ${error instanceof Error ? error.message : error}`
+          );
+        }
+
+        unverifiedPolicyIds.push(item.policyId);
+      })
+    );
+
+    if (unverifiedPolicyIds.length > 0) {
+      throw new BadRequestException(`All whitelist tokens must be verified.`);
     }
   }
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -2747,40 +2747,53 @@ export class GovernanceService {
 
     const unverifiedPolicyIds: string[] = [];
 
-    await Promise.all(
-      whitelistItems.map(async item => {
-        const existing = await this.tokenVerificationRepository.findOne({
-          where: { policy_id: item.policyId },
+    // Batch fetch all token verifications in a single query to avoid N+1
+    const policyIds = [...new Set(whitelistItems.map(item => item.policyId))];
+    const existingVerifications = policyIds.length
+      ? await this.tokenVerificationRepository.find({
+          where: { policy_id: In(policyIds) },
           order: { updated_at: 'DESC' },
-        });
+        })
+      : [];
 
-        if (existing?.is_verified) {
-          return;
+    // Build a map of policy_id -> most recent verification
+    const latestVerificationByPolicyId = new Map<string, TokenVerification>();
+    for (const verification of existingVerifications) {
+      if (!latestVerificationByPolicyId.has(verification.policy_id)) {
+        latestVerificationByPolicyId.set(verification.policy_id, verification);
+      }
+    }
+
+    // Process sequentially to avoid wasting external API calls
+    for (const item of whitelistItems) {
+      const existing = latestVerificationByPolicyId.get(item.policyId);
+
+      if (existing?.is_verified) {
+        continue;
+      }
+
+      const tokenId = `${item.policyId}${item.assetName || ''}`;
+      const dexHunterData = await this.dexHunterService.fetchTokenVerification(tokenId);
+      if (dexHunterData?.isVerified) {
+        continue;
+      }
+
+      try {
+        const wayupResponse = await this.wayUpPricingService.getCollectionAssets({ policyId: item.policyId });
+        const firstAsset = wayupResponse.results?.[0];
+        const hasResults = Array.isArray(wayupResponse.results) && wayupResponse.results.length > 0;
+
+        if (hasResults && firstAsset?.collection?.verified) {
+          continue;
         }
+      } catch (error) {
+        this.logger.warn(
+          `Failed to verify whitelist token ${item.policyId}: ${error instanceof Error ? error.message : error}`
+        );
+      }
 
-        const tokenId = `${item.policyId}${item.assetName || ''}`;
-        const dexHunterData = await this.dexHunterService.fetchTokenVerification(tokenId);
-        if (dexHunterData?.isVerified) {
-          return;
-        }
-
-        try {
-          const wayupResponse = await this.wayUpPricingService.getCollectionAssets({ policyId: item.policyId });
-          const firstAsset = wayupResponse.results?.[0];
-          const hasResults = Array.isArray(wayupResponse.results) && wayupResponse.results.length > 0;
-
-          if (hasResults && firstAsset?.collection?.verified) {
-            return;
-          }
-        } catch (error) {
-          this.logger.warn(
-            `Failed to verify whitelist token ${item.policyId}: ${error instanceof Error ? error.message : error}`
-          );
-        }
-
-        unverifiedPolicyIds.push(item.policyId);
-      })
-    );
+      unverifiedPolicyIds.push(item.policyId);
+    }
 
     if (unverifiedPolicyIds.length > 0) {
       throw new BadRequestException(`All whitelist tokens must be verified.`);

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -1384,9 +1384,8 @@ export class GovernanceService {
           );
         }
 
-        const uniqueWhitelistItems = Array.from(
-          new Map(assetsWhitelist.map(item => [`${item.policyId}:${item.assetName || ''}`, item])).values()
-        );
+        // Deduplicate by policyId only (matching the DB constraint: unique on vault + policy_id)
+        const uniqueWhitelistItems = Array.from(new Map(assetsWhitelist.map(item => [item.policyId, item])).values());
 
         const existingWhitelist = await this.assetsWhitelistRepository.find({
           where: { vault: { id: vaultId } },

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -422,10 +422,24 @@ export class GovernanceService {
 
     const vault: Pick<
       Vault,
-      'id' | 'vault_status' | 'script_hash' | 'asset_vault_name' | 'name' | 'assets_whitelist' | 'is_expandable'
+      | 'id'
+      | 'vault_status'
+      | 'script_hash'
+      | 'asset_vault_name'
+      | 'name'
+      | 'assets_whitelist'
+      | 'is_expandable_asset_whitelist'
     > = await this.vaultRepository.findOne({
       where: { id: vaultId },
-      select: ['id', 'vault_status', 'script_hash', 'asset_vault_name', 'name', 'assets_whitelist', 'is_expandable'],
+      select: [
+        'id',
+        'vault_status',
+        'script_hash',
+        'asset_vault_name',
+        'name',
+        'assets_whitelist',
+        'is_expandable_asset_whitelist',
+      ],
     });
 
     if (!vault) {
@@ -1356,7 +1370,7 @@ export class GovernanceService {
       }
 
       case ProposalType.ASSET_WHITELIST_UPDATE: {
-        if (!vault.is_expandable) {
+        if (!vault.is_expandable_asset_whitelist) {
           throw new BadRequestException(
             'This vault does not allow expanding the asset whitelist. Only vaults marked as expandable can create asset whitelist update proposals.'
           );

--- a/src/types/proposal.types.ts
+++ b/src/types/proposal.types.ts
@@ -24,6 +24,7 @@ export enum ProposalType {
   BUY_SELL = 'buy_sell', // Deprecated
   MARKETPLACE_ACTION = 'marketplace_action',
   EXPANSION = 'expansion',
+  ASSET_WHITELIST_UPDATE = 'asset_whitelist_update',
 }
 
 export enum MarketplaceAction {


### PR DESCRIPTION
This pull request introduces support for a new proposal type, "asset whitelist update," allowing vaults marked as expandable to update their asset whitelist via governance proposals. It includes all necessary backend changes: database migration, entity and DTO updates, proposal validation, and execution logic. The main themes are database/schema changes, API and DTO updates, and proposal execution logic.

**Database and Entity Changes:**

- Added a new boolean column `is_expandable` to the `vaults` table and corresponding entity property, marking vaults that allow whitelist expansion. [[1]](diffhunk://#diff-bc82b8c600d7c36641343a49f5b8025127c4c37722d01a7a08dbb5c84eb48db8R1-R33) [[2]](diffhunk://#diff-7cf633a4566d71fbb8aca846021ccc3ac2dfd1d54a5eff910f4cecfdcc953e56R736-R739)
- Extended the `proposal_proposal_type_enum` to include the new type `asset_whitelist_update`.

**API and DTO Updates:**

- Updated vault creation and draft endpoints to include the optional `isExpandable` field, with validation and OpenAPI documentation. [[1]](diffhunk://#diff-a9250e8c3a6d1c8f31bfd2d78c3e5adaeb1f9e82aad6d3e9ff0edffd66a4c59dR416-R425) [[2]](diffhunk://#diff-f965f6f7ac04552090aa483ebf47237afe5e618fd380410b141c7b087ad6c8d4R420-R431)
- Added support for the `assetsWhitelist` field in asset whitelist update proposals, including validation and API docs.
- Updated the `Proposal` entity to store `assetsWhitelist` metadata.
- Added `isExpandable` to the vault response DTOs for API consumers.

**Proposal Execution Logic:**

- Implemented execution for `ASSET_WHITELIST_UPDATE` proposals:
  - Only allowed if the vault is both expandable and in the LOCKED state.
  - Inserts new whitelist entries for the vault, skipping duplicates.
  - Rolls back inserts if the on-chain metadata update fails, ensuring consistency.
  - Stores detailed execution errors and user-friendly messages in proposal metadata. [[1]](diffhunk://#diff-72dcc07a226c6a9ff27c8a6e68cf5e94ad7eaa1b9a248551098359547f694b45R643-R666) [[2]](diffhunk://#diff-72dcc07a226c6a9ff27c8a6e68cf5e94ad7eaa1b9a248551098359547f694b45R690-R692) [[3]](diffhunk://#diff-72dcc07a226c6a9ff27c8a6e68cf5e94ad7eaa1b9a248551098359547f694b45R2087-R2219) [[4]](diffhunk://#diff-72dcc07a226c6a9ff27c8a6e68cf5e94ad7eaa1b9a248551098359547f694b45R2267-R2274)

These changes collectively enable secure and auditable asset whitelist updates for eligible vaults via governance.