### PR TITLE
ADDED: partner badge for vault

### DIFF
--- a/src/database/migrations/1778835830653-AddIsOfficialPartnerToVaults.ts
+++ b/src/database/migrations/1778835830653-AddIsOfficialPartnerToVaults.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIsOfficialPartnerToVaults1778835830653 implements MigrationInterface {
+  name = 'AddIsOfficialPartnerToVaults1778835830653';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "vaults" ADD "is_official_partner" boolean NOT NULL DEFAULT false`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "vaults" DROP COLUMN "is_official_partner"`);
+  }
+}

--- a/src/database/vault.entity.ts
+++ b/src/database/vault.entity.ts
@@ -737,6 +737,10 @@ export class Vault {
   @Column({ name: 'governance_phase_start', type: 'timestamptz', nullable: true })
   governance_phase_start?: Date;
 
+  @Expose({ name: 'isOfficialPartner' })
+  @Column({ name: 'is_official_partner', type: 'boolean', default: false })
+  is_official_partner: boolean;
+
   @BeforeInsert()
   setDate(): void {
     const now = new Date();

--- a/src/modules/vaults/dto/vault.response.ts
+++ b/src/modules/vaults/dto/vault.response.ts
@@ -151,6 +151,13 @@ export class VaultShortResponse {
     expose: true,
   })
   vaultTokenTicker?: string;
+
+  @ApiProperty({ description: 'Whether the vault is an official partner', default: false })
+  @DtoRepresent({
+    transform: false,
+    expose: { name: 'isOfficialPartner' },
+  })
+  isOfficialPartner: boolean;
 }
 
 export class VaultFullResponse extends VaultShortResponse {


### PR DESCRIPTION
This pull request adds support for marking vaults as official partners. The main changes include updating the database schema, the `Vault` entity, and the response DTOs to include a new `isOfficialPartner` field.

**Database schema changes:**
* Added a new boolean column `is_official_partner` to the `vaults` table, with a default value of `false`.

**Entity and DTO updates:**
* Updated the `Vault` entity to include the new `is_official_partner` field, mapped to the database column and exposed as `isOfficialPartner` in API responses.
* Updated the `VaultShortResponse` DTO to include the `isOfficialPartner` property, with appropriate API documentation and serialization settings.