### PR TITLE
ADDED: new filters for vaults

### DIFF
--- a/src/modules/vaults/dto/get-vaults.dto.ts
+++ b/src/modules/vaults/dto/get-vaults.dto.ts
@@ -178,6 +178,22 @@ export class GetVaultsDto extends PaginationDto {
   })
   reserveMet?: boolean;
 
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'Filter by official partner vaults',
+  })
+  @Expose()
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return value === 'true';
+    }
+    return value;
+  })
+  isOfficialPartner?: boolean;
+
   // Initial % Vault Offered Range
   @IsNumber()
   @IsOptional()
@@ -276,6 +292,71 @@ export class GetVaultsDto extends PaginationDto {
   })
   @Expose()
   tvlCurrency?: TVLCurrency = TVLCurrency.USD;
+
+  // FDV Range (stored in vault.fdv as ADA; USD filters use fdvCurrency)
+  @IsNumber()
+  @IsOptional()
+  @Min(0)
+  @ApiProperty({
+    type: Number,
+    required: false,
+    minimum: 0,
+    description: 'Minimum FDV value',
+  })
+  @Expose()
+  @Type(() => Number)
+  minFdv?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Min(0)
+  @ApiProperty({
+    type: Number,
+    required: false,
+    minimum: 0,
+    description: 'Maximum FDV value',
+  })
+  @Expose()
+  @Type(() => Number)
+  maxFdv?: number;
+
+  @IsEnum(TVLCurrency)
+  @IsOptional()
+  @ApiProperty({
+    enum: TVLCurrency,
+    required: false,
+    default: TVLCurrency.USD,
+    description: 'Currency for FDV filtering (ADA or USD)',
+  })
+  @Expose()
+  fdvCurrency?: TVLCurrency = TVLCurrency.USD;
+
+  // FDV/TVL ratio range (stored in vault.fdv_tvl)
+  @IsNumber()
+  @IsOptional()
+  @Min(0)
+  @ApiProperty({
+    type: Number,
+    required: false,
+    minimum: 0,
+    description: 'Minimum FDV/TVL ratio',
+  })
+  @Expose()
+  @Type(() => Number)
+  minFdvTvl?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Min(0)
+  @ApiProperty({
+    type: Number,
+    required: false,
+    minimum: 0,
+    description: 'Maximum FDV/TVL ratio',
+  })
+  @Expose()
+  @Type(() => Number)
+  maxFdvTvl?: number;
 
   // Contribution Window Filters
   @ApiProperty({

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -1275,6 +1275,11 @@ export class VaultsService {
       tvlCurrency,
       minTvl,
       maxTvl,
+      minFdv,
+      maxFdv,
+      fdvCurrency,
+      minFdvTvl,
+      maxFdvTvl,
       minInitialVaultOffered,
       maxInitialVaultOffered,
       contributionWindow,
@@ -1284,6 +1289,7 @@ export class VaultsService {
       myVaults,
       filter,
       reserveMet,
+      isOfficialPartner,
       search,
       page = 1,
       limit = 10,
@@ -1483,6 +1489,27 @@ export class VaultsService {
       }
     }
 
+    if (minFdv || maxFdv) {
+      const fdvDivider = fdvCurrency === TVLCurrency.USD ? await this.priceService.getAdaPrice() : 1;
+      const effectiveFdvDivider = fdvDivider > 0 ? fdvDivider : 1;
+
+      if (minFdv) {
+        queryBuilder.andWhere('vault.fdv >= :minFdv', { minFdv: minFdv / effectiveFdvDivider });
+      }
+
+      if (maxFdv) {
+        queryBuilder.andWhere('vault.fdv <= :maxFdv', { maxFdv: maxFdv / effectiveFdvDivider });
+      }
+    }
+
+    if (minFdvTvl) {
+      queryBuilder.andWhere('vault.fdv_tvl >= :minFdvTvl', { minFdvTvl });
+    }
+
+    if (maxFdvTvl) {
+      queryBuilder.andWhere('vault.fdv_tvl <= :maxFdvTvl', { maxFdvTvl });
+    }
+
     if (maxInitialVaultOffered) {
       queryBuilder.andWhere('(100 - vault.acquire_reserve) <= :maxInitialVaultOffered', { maxInitialVaultOffered });
     }
@@ -1501,6 +1528,10 @@ export class VaultsService {
         )`,
         { assetWhitelist }
       );
+    }
+
+    if (isOfficialPartner !== undefined) {
+      queryBuilder.andWhere('vault.is_official_partner = :isOfficialPartner', { isOfficialPartner });
     }
 
     // Apply sorting


### PR DESCRIPTION
This pull request adds new filtering capabilities to the vaults API, allowing users to filter vaults by official partner status, FDV (Fully Diluted Valuation) ranges, and FDV/TVL (Total Value Locked) ratio ranges. These changes enhance the flexibility and precision of vault searches.

**New filtering options in `GetVaultsDto` and query logic:**

*Official Partner Filter:*
- Added `isOfficialPartner` boolean filter to `GetVaultsDto` and query logic, allowing users to filter vaults by official partner status. [[1]](diffhunk://#diff-2b11d887604cebc1e6fac73cbce5c58c2a743c88ba87118d07ce418daabf6136R181-R196) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R1292) [[3]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R1533-R1536)

*FDV (Fully Diluted Valuation) Filters:*
- Added `minFdv`, `maxFdv`, and `fdvCurrency` fields to `GetVaultsDto` to filter vaults by FDV range in either ADA or USD, and updated query logic to handle currency conversion. [[1]](diffhunk://#diff-2b11d887604cebc1e6fac73cbce5c58c2a743c88ba87118d07ce418daabf6136R296-R360) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R1278-R1282) [[3]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R1492-R1512)

*FDV/TVL Ratio Filters:*
- Added `minFdvTvl` and `maxFdvTvl` fields to `GetVaultsDto` to filter vaults by FDV/TVL ratio range, and updated query logic accordingly. [[1]](diffhunk://#diff-2b11d887604cebc1e6fac73cbce5c58c2a743c88ba87118d07ce418daabf6136R296-R360) [[2]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R1278-R1282) [[3]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221R1492-R1512)

These enhancements provide users with more granular control when searching for vaults.