### PR TITLE
ADDED: on-chain massage for staking

### DIFF
--- a/src/common/cardano/cip674-metadata.ts
+++ b/src/common/cardano/cip674-metadata.ts
@@ -1,0 +1,40 @@
+/** Cardano CIP-20 / label-674 `msg` field: max 64 characters per chunk. */
+export const CIP674_MAX_CHUNK_LENGTH = 64;
+
+export type Cip674MetadataMessage = { msg: string[] };
+
+/** Splits a string into ≤64-char chunks, preferring breaks at whitespace. */
+export function chunkCip674Message(
+  raw: string,
+  options?: { maxChunkLength?: number; minSpaceBreakIndex?: number }
+): string[] {
+  const maxLen = options?.maxChunkLength ?? CIP674_MAX_CHUNK_LENGTH;
+  const minSpaceBreak = options?.minSpaceBreakIndex ?? 40;
+
+  const chunks: string[] = [];
+  let remaining = raw;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+
+    let breakPoint = maxLen;
+    const searchSpace = remaining.slice(0, maxLen + 1);
+    const lastSpace = searchSpace.lastIndexOf(' ');
+    if (lastSpace > minSpaceBreak) {
+      breakPoint = lastSpace;
+    }
+
+    chunks.push(remaining.slice(0, breakPoint).trimEnd());
+    remaining = remaining.slice(breakPoint).trimStart();
+  }
+
+  return chunks;
+}
+
+/** Builds `{ msg: string[] }` for `.attachMetadata(674, …)`. */
+export function formatCip674MetadataMessage(raw: string): Cip674MetadataMessage {
+  return { msg: chunkCip674Message(raw) };
+}

--- a/src/modules/stake/stake.service.ts
+++ b/src/modules/stake/stake.service.ts
@@ -24,6 +24,7 @@ import { toHumanAmountNumber } from './stake-amounts';
 import { encodeStakeDatum, tryDecodeStakeDatum } from './stake-datum';
 
 import { createLucidBlockfrostProvider, lucidNetworkFromCardanoEnv } from '@/common/cardano/blockfrost-lucid';
+import { formatCip674MetadataMessage } from '@/common/cardano/cip674-metadata';
 import { normalizeLucidCardanoError } from '@/common/cardano/lucid-error-normalizer';
 import { buildStakeTokenRegistry, type TokenMeta } from '@/common/cardano/token-registry';
 import { StakingStatus, TokenStakingPosition, TokenType } from '@/database/tokenStakingPosition.entity';
@@ -253,6 +254,43 @@ export class StakeService {
       referenceScript: { txHash: this.referenceScriptTxHash, outputIndex: this.referenceScriptIndex },
       cardanoNetwork: this.isMainnet ? 'mainnet' : 'preprod',
     };
+  }
+
+  private getTokenDisplayName(unit: string): string {
+    return this.getTokenTypeForUnit(unit) ?? 'token';
+  }
+
+  private formatHumanTokenAmounts(amounts: Array<{ unit: string; amount: number }>): string {
+    return amounts.map(({ unit, amount }) => `${amount} ${this.getTokenDisplayName(unit)}`).join(', ');
+  }
+
+  private buildStakeMetadataMessage(entries: Array<{ unit: string; rawAmount: bigint; decimals: number }>): {
+    msg: string[];
+  } {
+    const amounts = this.formatHumanTokenAmounts(
+      entries.map(e => ({ unit: e.unit, amount: toHumanAmountNumber(e.rawAmount, e.decimals) }))
+    );
+    return formatCip674MetadataMessage(`L4VA: Stake ${amounts}`);
+  }
+
+  private buildUnstakeMetadataMessage(processedBoxes: ProcessedBox[]): { msg: string[] } {
+    const summary = this.buildTokensSummary(processedBoxes);
+    const amounts = this.formatHumanTokenAmounts(summary.map(t => ({ unit: t.unit, amount: t.payoutAmount })));
+    const boxCount = processedBoxes.length;
+    const positionsLabel = boxCount === 1 ? '1 position' : `${boxCount} positions`;
+    return formatCip674MetadataMessage(`L4VA: Unstake ${positionsLabel} - withdraw ${amounts}`);
+  }
+
+  private buildHarvestMetadataMessage(processedBoxes: ProcessedBox[]): { msg: string[] } {
+    const summary = this.buildTokensSummary(processedBoxes);
+    const amounts = this.formatHumanTokenAmounts(summary.map(t => ({ unit: t.unit, amount: t.rewardAmount })));
+    return formatCip674MetadataMessage(`L4VA: Harvest staking rewards - ${amounts}`);
+  }
+
+  private buildCompoundMetadataMessage(processedBoxes: ProcessedBox[]): { msg: string[] } {
+    const summary = this.buildTokensSummary(processedBoxes);
+    const amounts = this.formatHumanTokenAmounts(summary.map(t => ({ unit: t.unit, amount: t.payoutAmount })));
+    return formatCip674MetadataMessage(`L4VA: Compound rewards into stake - ${amounts}`);
   }
 
   /**
@@ -763,6 +801,7 @@ export class StakeService {
       const tx = await txBuilder
         .validTo(currentTimeMs + TX_VALIDITY_WINDOW_MS)
         .addSignerKey(ownerHash)
+        .attachMetadata(674, this.buildStakeMetadataMessage(entries))
         .complete();
       const unsignedTxCbor = tx.toCBOR();
 
@@ -831,6 +870,7 @@ export class StakeService {
         .pay.ToAddress(userAddress, Object.fromEntries(payoutByUnit.entries()))
         .validTo(validTo)
         .addSignerKey(ownerHash)
+        .attachMetadata(674, this.buildUnstakeMetadataMessage(processedBoxes))
         .complete();
 
       const unsignedTxCbor = tx.toCBOR();
@@ -895,7 +935,11 @@ export class StakeService {
 
       txBuilder = txBuilder.pay.ToAddress(userAddress, Object.fromEntries(rewardByUnit.entries()));
 
-      const tx = await txBuilder.validTo(validTo).addSignerKey(ownerHash).complete();
+      const tx = await txBuilder
+        .validTo(validTo)
+        .addSignerKey(ownerHash)
+        .attachMetadata(674, this.buildHarvestMetadataMessage(processedBoxes))
+        .complete();
       const unsignedTxCbor = tx.toCBOR();
 
       const saved = await this.transactionRepository.save({
@@ -955,7 +999,11 @@ export class StakeService {
         );
       }
 
-      const tx = await txBuilder.validTo(validTo).addSignerKey(ownerHash).complete();
+      const tx = await txBuilder
+        .validTo(validTo)
+        .addSignerKey(ownerHash)
+        .attachMetadata(674, this.buildCompoundMetadataMessage(processedBoxes))
+        .complete();
       const unsignedTxCbor = tx.toCBOR();
 
       const saved = await this.transactionRepository.save({

--- a/src/modules/vaults/phase-management/governance/governance-refund.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-refund.service.ts
@@ -7,6 +7,7 @@ import { Repository } from 'typeorm';
 
 import { TransactionsService } from '../../processing-tx/offchain-tx/transactions.service';
 
+import { formatCip674MetadataMessage } from '@/common/cardano/cip674-metadata';
 import { Proposal } from '@/database/proposal.entity';
 import { Transaction } from '@/database/transaction.entity';
 import { ProposalStatus } from '@/types/proposal.types';
@@ -236,28 +237,7 @@ export class GovernanceRefundService {
 
   private formatRefundMetadataMessage(proposalId: string, proposalTitle?: string): { msg: string[] } {
     const proposalLabel = proposalTitle?.trim() || proposalId;
-    const raw = `L4VA: Governance fee refund for proposal ${proposalLabel}`;
-
-    const chunks: string[] = [];
-    let remaining = raw;
-    while (remaining.length > 0) {
-      if (remaining.length <= 64) {
-        chunks.push(remaining);
-        break;
-      }
-
-      let breakPoint = 64;
-      const searchSpace = remaining.slice(0, 65);
-      const lastSpace = searchSpace.lastIndexOf(' ');
-      if (lastSpace > 40) {
-        breakPoint = lastSpace;
-      }
-
-      chunks.push(remaining.slice(0, breakPoint).trimEnd());
-      remaining = remaining.slice(breakPoint).trimStart();
-    }
-
-    return { msg: chunks };
+    return formatCip674MetadataMessage(`L4VA: Governance fee refund for proposal ${proposalLabel}`);
   }
 
   // Retry failed/pending refunds on rejected proposals.


### PR DESCRIPTION
This pull request adds CIP-20 label 674 metadata messages to staking-related transactions, improving wallet UX by providing clear, user-friendly descriptions when users sign transactions. The main changes involve generating and attaching these messages for stake, unstake, harvest, and compound actions.

**CIP-20 Metadata Integration:**

* Added helper methods to format and chunk metadata messages according to CIP-20 label 674, ensuring messages are concise and readable in wallets.
* Implemented specific message builders for staking, unstaking, harvesting, and compounding actions, summarizing token amounts and actions in a user-friendly format.

**Transaction Construction Updates:**

* Modified the staking transaction flow to attach the new CIP-20 metadata message when building the transaction.
* Updated the unstake, harvest, and compound transaction flows to include the relevant CIP-20 metadata messages, ensuring all user actions are clearly described in the wallet. [[1]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53R892) [[2]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53L898-R961) [[3]](diffhunk://#diff-ce6539b60c9c6c8ea9d5026f7ccd63f452be705b4ecb9ec773b0c4d99e962c53L958-R1025)