### PR TITLE
Enhance token metadata logging and improve widget-swap logic

### DIFF
--- a/src/modules/rewards/rewards.controller.ts
+++ b/src/modules/rewards/rewards.controller.ts
@@ -80,14 +80,22 @@ export class RewardsController {
         ? [body as WidgetSwapItemData]
         : [];
 
+    // Find successful swap: if tx_hash exists, the swap was successful
+    // Also normalize field names for DexHunter compatibility (token_in/out → token_id_in/out)
     const successfulSwap = swaps.find(swap => {
-      const status = String(swap?.status ?? '').toLowerCase();
-      return !!swap?.tx_hash && (status === 'submitted' || status === 'success');
+      return !!swap?.tx_hash;
     });
 
     if (!successfulSwap) {
-      return { indexed: false, reason: 'swap not successful' };
+      return { indexed: false, reason: 'no transaction hash found' };
     }
+
+    // Normalize DexHunter field names for backward compatibility
+    const normalizedSwap = {
+      ...successfulSwap,
+      token_id_in: successfulSwap.token_id_in || (successfulSwap as any).token_in || '',
+      token_id_out: successfulSwap.token_id_out || (successfulSwap as any).token_out || '',
+    };
 
     // Extract policy IDs from token units (first 56 characters)
     const extractPolicyId = (tokenUnit: string): string | null => {
@@ -98,8 +106,8 @@ export class RewardsController {
       return tokenUnit.length >= 56 ? tokenUnit.substring(0, 56) : tokenUnit;
     };
 
-    const policyIdIn = extractPolicyId(successfulSwap.token_id_in);
-    const policyIdOut = extractPolicyId(successfulSwap.token_id_out);
+    const policyIdIn = extractPolicyId(normalizedSwap.token_id_in);
+    const policyIdOut = extractPolicyId(normalizedSwap.token_id_out);
 
     // Check if either token is a VT (matches a vault's policy_id)
     const policyIds = [policyIdIn, policyIdOut].filter(Boolean);
@@ -118,17 +126,17 @@ export class RewardsController {
 
     // Index VT swap event (vault-scoped)
     const event = await this.rewardEventProducer.indexEvent({
-      walletAddress: successfulSwap.user_address || req.user.address,
+      walletAddress: normalizedSwap.user_address || req.user.address,
       vaultId: vault.id,
       eventType: RewardActivityType.WIDGET_SWAP,
-      txHash: successfulSwap.tx_hash,
+      txHash: normalizedSwap.tx_hash,
       units: 1,
       metadata: {
-        dex: successfulSwap.dex,
-        tokenIn: successfulSwap.token_id_in,
-        tokenOut: successfulSwap.token_id_out,
-        amountIn: successfulSwap.amount_in,
-        expectedOutput: successfulSwap.expected_output,
+        dex: normalizedSwap.dex,
+        tokenIn: normalizedSwap.token_id_in,
+        tokenOut: normalizedSwap.token_id_out,
+        amountIn: normalizedSwap.amount_in,
+        expectedOutput: normalizedSwap.expected_output,
         vaultName: vault.name,
         vaultPolicyId: vault.script_hash,
       },

--- a/src/modules/vaults/phase-management/lifecycle/lifecycle.service.ts
+++ b/src/modules/vaults/phase-management/lifecycle/lifecycle.service.ts
@@ -1676,7 +1676,7 @@ export class LifecycleService {
       // Submit token metadata PR now that decimals are finalized
       try {
         this.logger.log(
-          `Submitting token metadata PR for vault ${vault.id} with finalized decimals: ${optimalDecimals}`
+          `Submitting token metadata PR for vault ${vault.id} with finalized decimals: ${vault.ft_token_decimals}`
         );
         await this.metadataRegistryApiService.submitVaultTokenMetadata(vault.id);
       } catch (metadataError) {


### PR DESCRIPTION
This pull request primarily improves compatibility with DexHunter swaps in the rewards flow and enhances logging clarity in the vault lifecycle service. The main changes involve normalizing swap field names for backward compatibility, updating how swap data is processed, and clarifying a log message.

**Rewards swap compatibility and normalization:**

* Updated the swap success check to only require a transaction hash (`tx_hash`), making the logic more robust and compatible with different swap sources.
* Normalized swap field names (`token_in`/`token_out` to `token_id_in`/`token_id_out`) to ensure compatibility with both legacy and DexHunter data formats.
* Updated subsequent references in the code to use the normalized swap object, ensuring consistent data handling throughout the rewards indexing process. [[1]](diffhunk://#diff-a75b9d36eb3b8d39d597b91ffd0b992ddbc65dccb136876b85faf960b068c638L101-R110) [[2]](diffhunk://#diff-a75b9d36eb3b8d39d597b91ffd0b992ddbc65dccb136876b85faf960b068c638L121-R139)

**Logging improvement:**

* Clarified the log message in the vault lifecycle service to display the finalized decimals from the vault object, improving traceability during the token metadata submission process.