### PR TITLE
Integrate VyFi service for LP token pricing and validation enhancements

### DIFF
--- a/src/database/migrations/1780064486958-AddVyfiPlatformEnum.ts
+++ b/src/database/migrations/1780064486958-AddVyfiPlatformEnum.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddVyfiPlatformEnum1780064486958 implements MigrationInterface {
+  name = 'AddVyfiPlatformEnum1780064486958';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Rename the old enum type
+    await queryRunner.query(
+      `ALTER TYPE "public"."token_verifications_platform_enum" RENAME TO "token_verifications_platform_enum_old"`
+    );
+
+    // Create the new enum type with 'vyfi' added
+    await queryRunner.query(
+      `CREATE TYPE "public"."token_verifications_platform_enum" AS ENUM('dexhunter', 'wayup', 'taptools', 'vyfi', 'manual', 'jpg.store')`
+    );
+
+    // Update the column to use the new enum type
+    await queryRunner.query(
+      `ALTER TABLE "token_verifications" ALTER COLUMN "platform" TYPE "public"."token_verifications_platform_enum" USING "platform"::"text"::"public"."token_verifications_platform_enum"`
+    );
+
+    // Drop the old enum type
+    await queryRunner.query(`DROP TYPE "public"."token_verifications_platform_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Rename the current enum type
+    await queryRunner.query(
+      `ALTER TYPE "public"."token_verifications_platform_enum" RENAME TO "token_verifications_platform_enum_old"`
+    );
+
+    // Recreate the old enum type without 'vyfi'
+    await queryRunner.query(
+      `CREATE TYPE "public"."token_verifications_platform_enum" AS ENUM('dexhunter', 'wayup', 'taptools', 'manual', 'jpg.store')`
+    );
+
+    // Update the column to use the old enum type
+    await queryRunner.query(
+      `ALTER TABLE "token_verifications" ALTER COLUMN "platform" TYPE "public"."token_verifications_platform_enum" USING "platform"::"text"::"public"."token_verifications_platform_enum"`
+    );
+
+    // Drop the renamed enum type
+    await queryRunner.query(`DROP TYPE "public"."token_verifications_platform_enum_old"`);
+  }
+}

--- a/src/database/migrations/1780064486958-AddVyfiPlatformEnum.ts
+++ b/src/database/migrations/1780064486958-AddVyfiPlatformEnum.ts
@@ -34,6 +34,9 @@ export class AddVyfiPlatformEnum1780064486958 implements MigrationInterface {
       `CREATE TYPE "public"."token_verifications_platform_enum" AS ENUM('dexhunter', 'wayup', 'taptools', 'manual', 'jpg.store')`
     );
 
+    // Map any 'vyfi' rows to NULL so the down migration can run safely
+    await queryRunner.query(`UPDATE "token_verifications" SET "platform" = NULL WHERE "platform" = 'vyfi'`);
+
     // Update the column to use the old enum type
     await queryRunner.query(
       `ALTER TABLE "token_verifications" ALTER COLUMN "platform" TYPE "public"."token_verifications_platform_enum" USING "platform"::"text"::"public"."token_verifications_platform_enum"`

--- a/src/database/token-verification.entity.ts
+++ b/src/database/token-verification.entity.ts
@@ -4,6 +4,7 @@ export enum VerificationPlatform {
   DEXHUNTER = 'dexhunter',
   WAYUP = 'wayup',
   TAPTOOLS = 'taptools',
+  VYFI = 'vyfi',
   MANUAL = 'manual',
   JPG_STORE = 'jpg.store',
 }

--- a/src/modules/taptools/taptools.module.ts
+++ b/src/modules/taptools/taptools.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { VyfiModule } from '../vyfi/vyfi.module';
@@ -25,7 +25,7 @@ import { WayUpPricingModule } from '@/modules/wayup/wayup-pricing.module';
     DexHunterPricingModule,
     TapToolsPricingModule,
     WayUpPricingModule,
-    forwardRef(() => VyfiModule),
+    VyfiModule,
   ],
   providers: [TaptoolsService],
   exports: [TaptoolsService],

--- a/src/modules/taptools/taptools.module.ts
+++ b/src/modules/taptools/taptools.module.ts
@@ -1,5 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { VyfiModule } from '../vyfi/vyfi.module';
 
 import { TaptoolsController } from './taptools.controller';
 import { TaptoolsService } from './taptools.service';
@@ -23,6 +25,7 @@ import { WayUpPricingModule } from '@/modules/wayup/wayup-pricing.module';
     DexHunterPricingModule,
     TapToolsPricingModule,
     WayUpPricingModule,
+    forwardRef(() => VyfiModule),
   ],
   providers: [TaptoolsService],
   exports: [TaptoolsService],

--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -1684,8 +1684,8 @@ export class TaptoolsService {
       }
 
       const totalSupply = await this.fetchLpTokenTotalSupply(lpTokenUnit);
-      if (!totalSupply) {
-        this.logger.warn(`No total supply found for LP token ${lpTokenUnit}`);
+      if (!totalSupply || totalSupply <= 0 || !Number.isSafeInteger(totalSupply)) {
+        this.logger.warn(`Invalid/unsafe total supply for LP token ${lpTokenUnit}: ${totalSupply}`);
         return null;
       }
 
@@ -1769,13 +1769,11 @@ export class TaptoolsService {
       if (!poolData || !poolData.lpTokenUnit) {
         this.logger.warn(`No pool data found in TapTools for onchain ID ${onchainID}`);
 
-        // Try VyFi fallback if LP token unit is provided
-        if (lpTokenUnit && this.vyfiService) {
+        // VyFi fallback: when onchainID is encoded as "tokenAUnit:tokenBUnit"
+        if (lpTokenUnit && this.vyfiService && onchainID.includes(':')) {
           this.logger.debug('Attempting VyFi fallback for LP price calculation');
-          // We need to extract tokenA and tokenB from somewhere
-          // For now, return null - caller should use calculateLpTokenPriceFromVyFi directly
-          // when they know it's a VyFi-only pool
-          return null;
+          const [tokenAUnit, tokenBUnit] = onchainID.split(':');
+          return this.calculateLpTokenPriceFromVyFi(tokenAUnit, tokenBUnit || '', lpTokenUnit);
         }
 
         return null;

--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -9,6 +9,7 @@ import { In, Repository } from 'typeorm';
 
 import { DexHunterPricingService } from '../dexhunter/dexhunter-pricing.service';
 import { VaultAssetsSummaryDto } from '../vaults/processing-tx/offchain-tx/dto/vault-assets-summary.dto';
+import { VyfiService } from '../vyfi/vyfi.service';
 import { WayUpPricingService } from '../wayup/wayup-pricing.service';
 
 import { AssetValueDto, BlockfrostAssetResponseDto } from './dto/asset-value.dto';
@@ -116,6 +117,7 @@ export class TaptoolsService {
     private readonly wayUpPricingService: WayUpPricingService,
     private readonly alertsService: AlertsService,
     private readonly tapToolsClient: TapToolsClient,
+    private readonly vyfiService?: VyfiService,
     @Optional() @Inject('TreasuryWalletService') private readonly treasuryWalletService?: TreasuryWalletService
   ) {
     this.isMainnet = this.configService.get<string>('CARDANO_NETWORK') === 'mainnet';
@@ -1654,18 +1656,128 @@ export class TaptoolsService {
   }
 
   /**
+   * Calculate LP token price from VyFi pool data
+   * Used as fallback when TapTools doesn't have the pool
+   * @param tokenAUnit - TokenA unit (hex)
+   * @param tokenBUnit - TokenB unit (hex or empty for ADA)
+   * @param lpTokenUnit - Full LP token unit for supply lookup
+   * @returns LP token price in ADA per normalized unit
+   */
+  private async calculateLpTokenPriceFromVyFi(
+    tokenAUnit: string,
+    tokenBUnit: string,
+    lpTokenUnit: string
+  ): Promise<number | null> {
+    if (!this.vyfiService) {
+      this.logger.warn('VyfiService not available for LP price calculation');
+      return null;
+    }
+
+    try {
+      // Convert empty tokenB to 'lovelace' for VyFi API
+      const tokenBQuery = !tokenBUnit || tokenBUnit === '' ? 'lovelace' : tokenBUnit;
+
+      const poolData = await this.vyfiService.getVyFiPoolData(tokenAUnit, tokenBQuery);
+      if (!poolData) {
+        this.logger.warn(`No VyFi pool found for ${tokenAUnit}/${tokenBQuery}`);
+        return null;
+      }
+
+      const totalSupply = await this.fetchLpTokenTotalSupply(lpTokenUnit);
+      if (!totalSupply) {
+        this.logger.warn(`No total supply found for LP token ${lpTokenUnit}`);
+        return null;
+      }
+
+      // VyFi returns quantities in base units, normalize them
+      const tokenALocked = poolData.tokenAQuantity;
+      const tokenBLocked = poolData.tokenBQuantity;
+
+      this.logger.debug(
+        `VyFi pool data - tokenALocked: ${tokenALocked}, tokenBLocked: ${tokenBLocked}, lpSupply: ${totalSupply}`
+      );
+
+      // Get token decimals from Blockfrost
+      let tokenADecimals = 6; // Default to 6
+      let tokenBDecimals = 6; // Default to 6 (ADA standard)
+
+      try {
+        const tokenAMetadata = await this.blockfrost.assetsById(tokenAUnit);
+        tokenADecimals = tokenAMetadata.metadata?.decimals ?? 6;
+      } catch (error) {
+        this.logger.warn(`Failed to fetch decimals for tokenA ${tokenAUnit}, using default 6`);
+      }
+
+      // TokenB decimals
+      const isTokenBAda = !tokenBUnit || tokenBUnit === '' || tokenBUnit === 'lovelace';
+      if (!isTokenBAda) {
+        try {
+          const tokenBMetadata = await this.blockfrost.assetsById(tokenBUnit);
+          tokenBDecimals = tokenBMetadata.metadata?.decimals ?? 6;
+        } catch (error) {
+          this.logger.warn(`Failed to fetch decimals for tokenB ${tokenBUnit}, using default 6`);
+        }
+      }
+
+      // Get token prices
+      let tokenAPrice = 0;
+      let tokenBPrice = 0;
+
+      // TokenB is ADA if tokenBUnit is empty or 'lovelace'
+      if (isTokenBAda) {
+        tokenBPrice = 1;
+      } else {
+        tokenBPrice = (await this.dexHunterPricingService.getTokenPrice(tokenBUnit)) || 0;
+      }
+
+      // TokenA price (could be another LP token!)
+      tokenAPrice = (await this.dexHunterPricingService.getTokenPrice(tokenAUnit)) || 0;
+
+      // Calculate TVL
+      // VyFi returns quantities in base units, normalize using actual decimals from Blockfrost
+      const tokenANormalized = tokenALocked / Math.pow(10, tokenADecimals);
+      const tokenBNormalized = tokenBLocked / Math.pow(10, tokenBDecimals);
+
+      const tvl = tokenANormalized * tokenAPrice + tokenBNormalized * tokenBPrice;
+      const lpTokenPrice = tvl / totalSupply;
+
+      this.logger.debug(
+        `VyFi LP price calculation - tokenAPrice: ${tokenAPrice} (decimals: ${tokenADecimals}), tokenBPrice: ${tokenBPrice} (decimals: ${tokenBDecimals}), TVL: ${tvl}, LP price: ${lpTokenPrice}`
+      );
+
+      return lpTokenPrice;
+    } catch (error) {
+      this.logger.error(`Failed to calculate LP price from VyFi: ${error.message}`, error);
+      return null;
+    }
+  }
+
+  /**
    * Calculate LP token price dynamically from pool TVL
    * Formula: LP Token Price = TVL / Total LP Token Supply
    * TVL = (tokenALocked * tokenAPrice) + (tokenBLocked * tokenBPrice)
    *
-   * @param onchainID - Pool onchain ID
+   * Falls back to VyFi API if TapTools doesn't have the pool data
+   *
+   * @param onchainID - Pool onchain ID (can be VyFi onchain ID format)
+   * @param lpTokenUnit - Optional: Full LP token unit to enable VyFi fallback
    * @returns LP token price in ADA per normalized unit
    */
-  private async calculateLpTokenPrice(onchainID: string): Promise<number | null> {
+  private async calculateLpTokenPrice(onchainID: string, lpTokenUnit?: string): Promise<number | null> {
     try {
       const poolData = await this.tapToolsClient.getPoolByOnchainId(onchainID);
       if (!poolData || !poolData.lpTokenUnit) {
-        this.logger.warn(`No pool data found for onchain ID ${onchainID}`);
+        this.logger.warn(`No pool data found in TapTools for onchain ID ${onchainID}`);
+
+        // Try VyFi fallback if LP token unit is provided
+        if (lpTokenUnit && this.vyfiService) {
+          this.logger.debug('Attempting VyFi fallback for LP price calculation');
+          // We need to extract tokenA and tokenB from somewhere
+          // For now, return null - caller should use calculateLpTokenPriceFromVyFi directly
+          // when they know it's a VyFi-only pool
+          return null;
+        }
+
         return null;
       }
 
@@ -1731,9 +1843,44 @@ export class TaptoolsService {
           whitelistItem.valuation_method === AssetValuationMethod.LP_TOKEN_DYNAMIC &&
           whitelistItem.lp_pool_onchain_id
         ) {
-          const lpPrice = await this.calculateLpTokenPrice(whitelistItem.lp_pool_onchain_id);
+          let lpPrice: number | null = null;
+
+          // Check if this is a VyFi pool (format: tokenA:tokenB)
+          if (whitelistItem.lp_pool_onchain_id.includes(':')) {
+            // VyFi LP token: parse tokenA and tokenB from colon-separated format
+            const [tokenAUnit, tokenBUnit] = whitelistItem.lp_pool_onchain_id.split(':');
+
+            // Get the full LP token unit from assets table
+            const lpAsset = await this.assetRepository.findOne({
+              where: {
+                vault_id: vaultId,
+                policy_id: whitelistItem.policy_id,
+              },
+            });
+
+            if (lpAsset) {
+              const lpTokenUnit = lpAsset.policy_id + lpAsset.asset_id;
+
+              this.logger.debug(
+                `VyFi LP token detected for ${whitelistItem.policy_id}: tokenA=${tokenAUnit}, tokenB=${tokenBUnit}, lpUnit=${lpTokenUnit}`
+              );
+
+              lpPrice = await this.calculateLpTokenPriceFromVyFi(tokenAUnit, tokenBUnit || '', lpTokenUnit);
+            } else {
+              this.logger.warn(
+                `VyFi LP token ${whitelistItem.policy_id} not found in vault ${vaultId} assets - cannot calculate price`
+              );
+            }
+          } else {
+            // TapTools LP token: use onchainID directly
+            lpPrice = await this.calculateLpTokenPrice(whitelistItem.lp_pool_onchain_id);
+          }
+
           if (lpPrice !== null && lpPrice !== undefined && Number.isFinite(lpPrice)) {
             customPriceMap.set(whitelistItem.policy_id, lpPrice);
+            this.logger.debug(`LP price for ${whitelistItem.policy_id}: ${lpPrice} ADA`);
+          } else {
+            this.logger.warn(`Failed to calculate LP price for ${whitelistItem.policy_id}`);
           }
         }
       }

--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -117,7 +117,7 @@ export class TaptoolsService {
     private readonly wayUpPricingService: WayUpPricingService,
     private readonly alertsService: AlertsService,
     private readonly tapToolsClient: TapToolsClient,
-    private readonly vyfiService?: VyfiService,
+    private readonly vyfiService: VyfiService,
     @Optional() @Inject('TreasuryWalletService') private readonly treasuryWalletService?: TreasuryWalletService
   ) {
     this.isMainnet = this.configService.get<string>('CARDANO_NETWORK') === 'mainnet';

--- a/src/modules/vyfi/vyfi.module.ts
+++ b/src/modules/vyfi/vyfi.module.ts
@@ -1,5 +1,5 @@
 import { HttpModule } from '@nestjs/axios';
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
@@ -12,7 +12,12 @@ import { Transaction } from '@/database/transaction.entity';
 import { Vault } from '@/database/vault.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Claim, Transaction, Vault]), HttpModule, ConfigModule, BlockchainModule],
+  imports: [
+    TypeOrmModule.forFeature([Claim, Transaction, Vault]),
+    HttpModule,
+    ConfigModule,
+    forwardRef(() => BlockchainModule),
+  ],
   providers: [VyfiService],
   exports: [VyfiService],
 })

--- a/src/modules/vyfi/vyfi.service.ts
+++ b/src/modules/vyfi/vyfi.service.ts
@@ -168,6 +168,73 @@ export class VyfiService {
   }
 
   /**
+   * Get pool data by LP token unit
+   * Queries all VyFi pools and finds the one matching the LP token
+   * @param lpTokenUnit - Full LP token unit (policyId + assetName in hex)
+   * @returns VyFi pool data or null if not found
+   */
+  async getPoolByLpToken(lpTokenUnit: string): Promise<VyFiPoolData | null> {
+    try {
+      // Extract policy and asset from full unit
+      const policyId = lpTokenUnit.substring(0, 56);
+      const assetName = lpTokenUnit.substring(56);
+      const lpTokenIdentifier = `${policyId}-${assetName}`;
+
+      // VyFi doesn't have a direct endpoint for LP token lookup
+      // We need to try to parse the asset name to extract token pair
+      // Asset name format: "VyFi_VLRM/ORACLE_LP" or similar
+      // But we can also use the checkPool endpoint by iterating through possible pairs
+      // For now, let's use a more direct approach - query VyFi's all pools endpoint if available
+      // Or we can check if the LP token identifier matches
+
+      this.logger.debug(`Looking up VyFi pool for LP token: ${lpTokenIdentifier}`);
+
+      // Try to decode the asset name to get token pair hints
+      // Asset name is in hex, decode it
+      const decodedAssetName = Buffer.from(assetName, 'hex').toString('utf8');
+      this.logger.debug(`Decoded LP token name: ${decodedAssetName}`);
+
+      // The problem is we need to know the token pair to query VyFi
+      // VyFi doesn't have a reverse lookup endpoint
+      // For now, return null and let caller handle it differently
+      // In the future, could implement a cache or registry of known pools
+
+      return null;
+    } catch (error) {
+      this.logger.error(`Failed to get pool by LP token: ${error.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Get VyFi pool data directly from API by token units
+   * This method returns the raw VyFi pool data with quantities in base units
+   * @param tokenAUnit - First token unit (hex)
+   * @param tokenBUnit - Second token unit (hex or 'lovelace' for ADA)
+   * @returns Raw VyFi pool data with quantities or null
+   */
+  async getVyFiPoolData(tokenAUnit: string, tokenBUnit: string = 'lovelace'): Promise<VyFiPoolData | null> {
+    try {
+      const poolCheck = await this.checkPool({
+        tokenAUnit,
+        tokenBUnit,
+      });
+
+      if (!poolCheck.exists || !poolCheck.data) {
+        return null;
+      }
+
+      // VyFi API returns an array, get the first pool
+      const poolData: VyFiPoolData | undefined = Array.isArray(poolCheck.data) ? poolCheck.data[0] : poolCheck.data;
+
+      return poolData || null;
+    } catch (error) {
+      this.logger.error(`Failed to get VyFi pool data: ${error.message}`);
+      return null;
+    }
+  }
+
+  /**
    * Get pool info by token pair
    * Returns pool data including pool validator address, order validator address, LP token unit, and reserves
    */

--- a/src/modules/vyfi/vyfi.service.ts
+++ b/src/modules/vyfi/vyfi.service.ts
@@ -168,10 +168,13 @@ export class VyfiService {
   }
 
   /**
-   * Get pool data by LP token unit
-   * Queries all VyFi pools and finds the one matching the LP token
+   * Get pool data by LP token unit.
+   *
+   * Note: VyFi API doesn't currently provide a reverse-lookup endpoint for LP token units,
+   * so this method returns null for now.
+   *
    * @param lpTokenUnit - Full LP token unit (policyId + assetName in hex)
-   * @returns VyFi pool data or null if not found
+   * @returns VyFi pool data or null (always null until reverse lookup is implemented)
    */
   async getPoolByLpToken(lpTokenUnit: string): Promise<VyFiPoolData | null> {
     try {


### PR DESCRIPTION
This pull request adds support for the VyFi platform as a new LP (liquidity pool) price data source and integrates it as a fallback for LP price calculations when TapTools data is unavailable. The changes include updating the database schema, extending enums, enhancing service logic, and improving module dependencies to support VyFi-based workflows.

**VyFi Platform Integration:**

- Added `vyfi` as a new value to the `VerificationPlatform` enum and updated the `token_verifications_platform_enum` in the database schema via a new migration. [[1]](diffhunk://#diff-758c3d8eb42e24e22a64df1cf89a613c69383aebb357194c0092845cf5ec0860R7) [[2]](diffhunk://#diff-6decf8bf96501b518086dc0c916f18990ac54299d6ebf841077a128c7a78d0ebR1-R48)

**LP Price Calculation Enhancements:**

- Implemented a fallback mechanism in `TaptoolsService` to calculate LP token prices using VyFi pool data when TapTools does not have the required pool information. This includes a new method `calculateLpTokenPriceFromVyFi` and logic to detect VyFi pools based on a colon-separated `onchainID` format. [[1]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548R1658-R1778) [[2]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L1734-R1881)
- Updated the LP price calculation workflow to support both TapTools and VyFi sources, including improved logging and error handling for price lookup failures.

**VyFi Service Improvements:**

- Added `getVyFiPoolData` to fetch pool data directly from the VyFi API using token units, and a placeholder `getPoolByLpToken` for future reverse-lookup support.

**Module and Dependency Updates:**

- Refactored `TaptoolsModule` and `VyfiModule` to use `forwardRef` for proper dependency injection, enabling cross-module service usage without circular dependency issues. [[1]](diffhunk://#diff-1ffa2747e97a889957c39190332ec3b5abc73f3e8bb7bc45d0b87496840a78b5L1-R5) [[2]](diffhunk://#diff-1ffa2747e97a889957c39190332ec3b5abc73f3e8bb7bc45d0b87496840a78b5R28) [[3]](diffhunk://#diff-c4c0cf4bd2a5e25d6664d180a0075eae21d788ba1891642e6506d83278655d47L2-R2) [[4]](diffhunk://#diff-c4c0cf4bd2a5e25d6664d180a0075eae21d788ba1891642e6506d83278655d47L15-R20)
- Injected `VyfiService` into `TaptoolsService` to enable VyFi-based price calculations. [[1]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548R12) [[2]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548R120)

These changes collectively ensure that LP token price calculations are more robust and can fall back to VyFi data, improving reliability for assets not covered by TapTools.