### PR TITLE
Add is_expansion field and improve consistency in TransactionsService

### DIFF
--- a/src/modules/vaults/draft-vaults.service.ts
+++ b/src/modules/vaults/draft-vaults.service.ts
@@ -42,7 +42,7 @@ export class DraftVaultsService {
     @InjectRepository(TagEntity)
     private readonly tagsRepository: Repository<TagEntity>,
     @InjectRepository(TokenVerification)
-    private readonly tokenVerificationRepo: Repository<TokenVerification>
+    private readonly tokenVerificationRepository: Repository<TokenVerification>
   ) {}
 
   async getMyDraftVaults(
@@ -319,7 +319,7 @@ export class DraftVaultsService {
         const policyIds = data.assetsWhitelist.map(item => item.policyId).filter(Boolean);
         const lpTokensData =
           policyIds.length > 0
-            ? await this.tokenVerificationRepo.find({
+            ? await this.tokenVerificationRepository.find({
                 where: { policy_id: In(policyIds) },
                 select: ['policy_id', 'lp_pool_onchain_id', 'is_lp_token'],
               })

--- a/src/modules/vaults/market-stats/vault-market-stats.service.ts
+++ b/src/modules/vaults/market-stats/vault-market-stats.service.ts
@@ -50,7 +50,7 @@ export class VaultMarketStatsService {
   private readonly isMainnet: boolean;
   private readonly axiosTapToolsInstance: AxiosInstance;
   private readonly ohlcvCache: NodeCache;
-  private readonly validOHLCVIntervals: readonly string[] = ['1h', '24h', '7d', '30d'];
+  private readonly validOHLCVIntervals: readonly string[] = ['1h', '1d', '1w', '1M'];
 
   constructor(
     @InjectRepository(Vault)
@@ -290,7 +290,7 @@ export class VaultMarketStatsService {
    *
    * @param scriptHash - is policyId for vault and its tokens
    * @param assetName - Token asset name (hex)
-   * @param interval - Time interval (1h, 24h, 7d, 30d, 1d)
+   * @param interval - Time interval (1h, 1d, 1w, 1M)
    * @param numIntervals - Optional number of intervals to return (omit for full history)
    * @param cacheKey - Cache key for storing/retrieving cached data
    * @returns OHLCV data array or null if unavailable

--- a/src/modules/vaults/processing-tx/offchain-tx/dto/transactions-response.dto.ts
+++ b/src/modules/vaults/processing-tx/offchain-tx/dto/transactions-response.dto.ts
@@ -35,6 +35,9 @@ export class TransactionsResponseItemsDto {
   status?: TransactionStatus;
 
   @Expose()
+  is_expansion: boolean;
+
+  @Expose()
   amount: string;
 
   @Expose()

--- a/src/modules/vaults/processing-tx/offchain-tx/transactions.service.ts
+++ b/src/modules/vaults/processing-tx/offchain-tx/transactions.service.ts
@@ -434,6 +434,7 @@ export class TransactionsService {
         'transaction.amount',
         'transaction.metadata',
         'transaction.tx_hash',
+        'transaction.is_expansion',
         'transaction.updated_at',
         'transaction.created_at',
         'transaction.vault_id',

--- a/src/modules/vaults/token-verification-refresh.service.ts
+++ b/src/modules/vaults/token-verification-refresh.service.ts
@@ -17,7 +17,7 @@ export class TokenVerificationRefreshService {
 
   constructor(
     @InjectRepository(TokenVerification)
-    private readonly tokenVerificationRepo: Repository<TokenVerification>,
+    private readonly tokenVerificationRepository: Repository<TokenVerification>,
     private readonly dexHunterService: DexHunterService,
     private readonly wayUpPricingService: WayUpPricingService,
     private readonly configService: ConfigService
@@ -31,7 +31,7 @@ export class TokenVerificationRefreshService {
       return;
     }
 
-    const pending = await this.tokenVerificationRepo.find({
+    const pending = await this.tokenVerificationRepository.find({
       where: { is_verified: false },
       order: { updated_at: 'ASC' },
       take: BATCH_SIZE,
@@ -79,7 +79,7 @@ export class TokenVerificationRefreshService {
       row.is_verified = dexHunterData.isVerified;
       row.platform = VerificationPlatform.DEXHUNTER;
       if (this.hasChanged(prev, row)) {
-        await this.tokenVerificationRepo.save(row);
+        await this.tokenVerificationRepository.save(row);
         return true;
       }
       return false;
@@ -94,7 +94,7 @@ export class TokenVerificationRefreshService {
       row.is_verified = wayupData.isVerified;
       row.platform = VerificationPlatform.WAYUP;
       if (this.hasChanged(prev, row)) {
-        await this.tokenVerificationRepo.save(row);
+        await this.tokenVerificationRepository.save(row);
         return true;
       }
       return false;

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -118,7 +118,7 @@ export class VaultsService {
     @InjectRepository(Snapshot)
     private readonly snapshotRepository: Repository<Snapshot>,
     @InjectRepository(TokenVerification)
-    private readonly tokenVerificationRepo: Repository<TokenVerification>,
+    private readonly tokenVerificationRepository: Repository<TokenVerification>,
     private readonly gcsService: GoogleCloudStorageService,
     private readonly vaultContractService: VaultManagingService,
     private readonly blockchainService: BlockchainService,
@@ -415,7 +415,7 @@ export class VaultsService {
       const policyIds = uniquePolicyIds.map(item => item.policyId).filter(Boolean);
       const lpTokensData =
         policyIds.length > 0
-          ? await this.tokenVerificationRepo.find({
+          ? await this.tokenVerificationRepository.find({
               where: { policy_id: In(policyIds) },
               select: ['policy_id', 'lp_pool_onchain_id', 'is_lp_token'],
             })
@@ -2226,7 +2226,7 @@ export class VaultsService {
     const { policyId, assetName } = collection;
 
     // Always check database first for manually registered tokens (including LP tokens)
-    const existing = await this.tokenVerificationRepo.findOne({
+    const existing = await this.tokenVerificationRepository.findOne({
       where: { policy_id: policyId },
       order: { updated_at: 'DESC' },
     });
@@ -2251,7 +2251,7 @@ export class VaultsService {
 
     const dexHunterData = await this.dexHunterService.fetchTokenVerification(tokenId);
     if (dexHunterData !== null) {
-      return await this.tokenVerificationRepo.save(
+      return await this.tokenVerificationRepository.save(
         Object.assign(new TokenVerification(), {
           policy_id: policyId,
           token_id: tokenId,
@@ -2265,7 +2265,7 @@ export class VaultsService {
     try {
       const adaAnvilData = await this.fetchCollectionInfoFromApi(policyId);
       if (!adaAnvilData.hasResults) {
-        return await this.tokenVerificationRepo.save(
+        return await this.tokenVerificationRepository.save(
           Object.assign(new TokenVerification(), {
             policy_id: policyId,
             token_id: null,
@@ -2275,7 +2275,7 @@ export class VaultsService {
           })
         );
       }
-      return await this.tokenVerificationRepo.save(
+      return await this.tokenVerificationRepository.save(
         Object.assign(new TokenVerification(), {
           policy_id: policyId,
           token_id: null,


### PR DESCRIPTION
This pull request primarily focuses on code consistency and minor feature enhancements across the vault-related services. The most significant changes include standardizing the naming of the `TokenVerification` repository property throughout multiple service classes, updating the valid OHLCV intervals for market stats, and adding a new property to the transaction DTO for transaction expansion status.

**Repository naming consistency:**

* Renamed the `tokenVerificationRepo` property to `tokenVerificationRepository` in `DraftVaultsService`, `VaultsService`, and `TokenVerificationRefreshService`, and updated all usages accordingly to improve code clarity and consistency. [[1]](diffhunk://#diff-ebb6fc2e455f893b11a0ded7eaf16fe1f0458adbc64f79f8016fd37850325683L45-R45) [[2]](diffhunk://#diff-ebb6fc2e455f893b11a0ded7eaf16fe1f0458adbc64f79f8016fd37850325683L322-R322) [[3]](diffhunk://#diff-da3866c51a738f289024907b6895e8c2d0e543c21b03c988f20cb8cbf960bd65L20-R20) [[4]](diffhunk://#diff-da3866c51a738f289024907b6895e8c2d0e543c21b03c988f20cb8cbf960bd65L34-R34) [[5]](diffhunk://#diff-da3866c51a738f289024907b6895e8c2d0e543c21b03c988f20cb8cbf960bd65L82-R82) [[6]](diffhunk://#diff-da3866c51a738f289024907b6895e8c2d0e543c21b03c988f20cb8cbf960bd65L97-R97) [[7]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L121-R121) [[8]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L418-R418) [[9]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L2229-R2229) [[10]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L2254-R2254) [[11]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L2268-R2268) [[12]](diffhunk://#diff-c533a429f829a361df676fecc3f9456bf4e194e0c56d3bffdfc7148f91e6f221L2278-R2278)

**Market stats improvements:**

* Updated valid OHLCV intervals in `VaultMarketStatsService` from `['1h', '24h', '7d', '30d']` to `['1h', '1d', '1w', '1M']` and updated related documentation to reflect the new intervals, aligning with standard timeframes. [[1]](diffhunk://#diff-b1fbf0f0055071f1f1fe48f05f258dc6668d15aba1757312d339818ddf1fdcd6L53-R53) [[2]](diffhunk://#diff-b1fbf0f0055071f1f1fe48f05f258dc6668d15aba1757312d339818ddf1fdcd6L293-R293)

**Transaction DTO enhancements:**

* Added a new `is_expansion` property to the `TransactionsResponseItemsDto` and included it in the transaction selection in `TransactionsService` to expose whether a transaction is an expansion. [[1]](diffhunk://#diff-c22fdf341a0a87ec9d59da08f94970a4a089101a89db69f48ce868a8eb6c027cR37-R39) [[2]](diffhunk://#diff-1b9f814adb7defc4eb1bec1f39495152149b731c6c77060e2a0221e47f962a2cR437)