### PR TITLE
Enhance offer proposals handling and cancellation features

### DIFF
--- a/src/database/asset.entity.ts
+++ b/src/database/asset.entity.ts
@@ -184,6 +184,11 @@ export class Asset {
   @Column({ name: 'listing_price', type: 'decimal', precision: 20, scale: 6, nullable: true })
   listing_price?: number;
 
+  /**
+   * For LISTED assets: the marketplace listing tx hash (used for unlist/update).
+   *
+   * For OFFERED assets (origin_type=OFFERED): the WayUp offer placement tx hash (used for cancel-offer).
+   */
   @Expose({ name: 'listingTxHash' })
   @Column({ name: 'listing_tx_hash', type: 'text', nullable: true })
   listing_tx_hash?: string;

--- a/src/database/asset.entity.ts
+++ b/src/database/asset.entity.ts
@@ -181,7 +181,14 @@ export class Asset {
   listing_market?: string;
 
   @Expose({ name: 'listingPrice' })
-  @Column({ name: 'listing_price', type: 'decimal', precision: 20, scale: 6, nullable: true })
+  @Column({
+    name: 'listing_price',
+    type: 'decimal',
+    precision: 20,
+    scale: 6,
+    nullable: true,
+    transformer: new ColumnNumericTransformer(),
+  })
   listing_price?: number;
 
   /**

--- a/src/database/migrations/1779286343075-AddCancelOfferStatusAndOfferedOriginType.ts
+++ b/src/database/migrations/1779286343075-AddCancelOfferStatusAndOfferedOriginType.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCancelOfferStatusAndOfferedOriginType1779286343075 implements MigrationInterface {
+  name = 'AddCancelOfferStatusAndOfferedOriginType1779286343075';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TYPE "public"."assets_status_enum" RENAME TO "assets_status_enum_old"`);
+    await queryRunner.query(
+      `CREATE TYPE "public"."assets_status_enum" AS ENUM('pending', 'locked', 'released', 'distributed', 'extracted', 'listed', 'sold', 'burned', 'offered', 'cancel_offer')`
+    );
+    await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN "status" DROP DEFAULT`);
+    await queryRunner.query(
+      `ALTER TABLE "assets" ALTER COLUMN "status" TYPE "public"."assets_status_enum" USING "status"::"text"::"public"."assets_status_enum"`
+    );
+    await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN "status" SET DEFAULT 'pending'`);
+    await queryRunner.query(`DROP TYPE "public"."assets_status_enum_old"`);
+
+    await queryRunner.query(`ALTER TYPE "public"."assets_origin_type_enum" RENAME TO "assets_origin_type_enum_old"`);
+    await queryRunner.query(
+      `CREATE TYPE "public"."assets_origin_type_enum" AS ENUM('acquired', 'contributed', 'fee', 'bought', 'offered')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assets" ALTER COLUMN "origin_type" TYPE "public"."assets_origin_type_enum" USING "origin_type"::"text"::"public"."assets_origin_type_enum"`
+    );
+    await queryRunner.query(`DROP TYPE "public"."assets_origin_type_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TYPE "public"."assets_origin_type_enum" RENAME TO "assets_origin_type_enum_old"`);
+    await queryRunner.query(
+      `CREATE TYPE "public"."assets_origin_type_enum" AS ENUM('acquired', 'contributed', 'fee', 'bought')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assets" ALTER COLUMN "origin_type" TYPE "public"."assets_origin_type_enum" USING "origin_type"::"text"::"public"."assets_origin_type_enum"`
+    );
+    await queryRunner.query(`DROP TYPE "public"."assets_origin_type_enum_old"`);
+
+    await queryRunner.query(`ALTER TYPE "public"."assets_status_enum" RENAME TO "assets_status_enum_old"`);
+    await queryRunner.query(
+      `CREATE TYPE "public"."assets_status_enum" AS ENUM('pending', 'locked', 'released', 'distributed', 'extracted', 'listed', 'sold', 'burned', 'offered')`
+    );
+    await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN "status" DROP DEFAULT`);
+    await queryRunner.query(
+      `ALTER TABLE "assets" ALTER COLUMN "status" TYPE "public"."assets_status_enum" USING "status"::"text"::"public"."assets_status_enum"`
+    );
+    await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN "status" SET DEFAULT 'pending'`);
+    await queryRunner.query(`DROP TYPE "public"."assets_status_enum_old"`);
+  }
+}

--- a/src/database/migrations/1779286343075-AddCancelOfferStatusAndOfferedOriginType.ts
+++ b/src/database/migrations/1779286343075-AddCancelOfferStatusAndOfferedOriginType.ts
@@ -26,6 +26,10 @@ export class AddCancelOfferStatusAndOfferedOriginType1779286343075 implements Mi
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // Normalize values that don't exist in the previous enums to allow casting during rollback
+    await queryRunner.query(`UPDATE "assets" SET "origin_type" = 'bought' WHERE "origin_type" = 'offered'`);
+    await queryRunner.query(`UPDATE "assets" SET "status" = 'offered' WHERE "status" = 'cancel_offer'`);
+
     await queryRunner.query(`ALTER TYPE "public"."assets_origin_type_enum" RENAME TO "assets_origin_type_enum_old"`);
     await queryRunner.query(
       `CREATE TYPE "public"."assets_origin_type_enum" AS ENUM('acquired', 'contributed', 'fee', 'bought')`

--- a/src/database/proposal.entity.ts
+++ b/src/database/proposal.entity.ts
@@ -82,7 +82,7 @@ export class Proposal {
     fungibleTokens?: FungibleTokenDto[];
     nonFungibleTokens?: NonFungibleTokenDto[];
 
-    // Buy/Sell data
+    // Buy/Sell data - each action can include a displayName field (fetched from Blockfrost on-chain metadata)
     marketplaceActions?: MarketplaceActionDto[];
 
     // Distribution data - total lovelace amount to distribute

--- a/src/database/proposal.entity.ts
+++ b/src/database/proposal.entity.ts
@@ -99,10 +99,15 @@ export class Proposal {
       policyIds: string[];
       labels?: string[];
       duration?: number;
+      /** No time limit (always open) */
       noLimit?: boolean;
+      /** Max assets per expansion window */
       assetMax?: number;
+      /** No max assets limit */
       noMax?: boolean;
+      /** Pricing mode */
       priceType: 'limit' | 'market';
+      /** For limit: VT per 1 ADA */
       limitPrice?: number;
       currentAssetCount?: number; // Track progress
     };

--- a/src/modules/alerts/alerts.service.ts
+++ b/src/modules/alerts/alerts.service.ts
@@ -663,10 +663,7 @@ export class AlertsService {
             {
               type: 'context',
               elements: [
-                {
-                  type: 'mrkdwn',
-                  text: `*Timestamp:* ${timestamp} | *Environment:* Production`,
-                },
+                  text: `*Timestamp:* ${timestamp} | *Environment:* ${this.nodeEnv || 'unknown'}`,
               ],
             },
           ],

--- a/src/modules/alerts/alerts.service.ts
+++ b/src/modules/alerts/alerts.service.ts
@@ -22,12 +22,15 @@ export class AlertsService {
   private readonly logger = new Logger(AlertsService.name);
   private readonly slackToken: string;
   private readonly slackChannel: string;
+  private readonly nodeEnv: string;
+
   private readonly SLACK_ALERT_COOLDOWN = 60 * 60 * 1000; // 1 hour in milliseconds
   private lastSlackAlert = new Map<string, number>();
 
   constructor(private readonly configService: ConfigService) {
     this.slackToken = this.configService.get<string>('SLACK_BOT_TOKEN');
     this.slackChannel = `#${this.configService.get<string>('SLACK_CHANNEL')}`;
+    this.nodeEnv = this.configService.get<string>('NODE_ENV');
   }
 
   /**
@@ -39,6 +42,11 @@ export class AlertsService {
     try {
       if (!this.slackToken) {
         this.logger.debug('Slack token not configured, skipping alert');
+        return;
+      }
+
+      if (this.nodeEnv === 'development' || this.nodeEnv === 'dev') {
+        this.logger.debug(`Development environment detected, skipping Slack alert for ${alertType}`);
         return;
       }
 
@@ -578,6 +586,90 @@ export class AlertsService {
         return {
           text: `🚨 Stake Reward Distribution Failed - Insufficient Funds`,
           blocks,
+        };
+      }
+
+      case 'treasury_insufficient_funds_marketplace': {
+        const vaultName = data.vaultName || 'Unknown Vault';
+        const proposalTitle = data.proposalTitle || 'Unknown Proposal';
+        const requiredAda = data.requiredAda || 'unknown';
+        const treasuryAddress = data.treasuryAddress || 'Unknown';
+        const proposalId = data.proposalId || 'Unknown';
+
+        return {
+          text: `🚨 URGENT: Treasury Wallet Insufficient Funds for Marketplace Operation`,
+          blocks: [
+            {
+              type: 'header',
+              text: {
+                type: 'plain_text',
+                text: `🚨 Treasury Wallet Insufficient Funds`,
+                emoji: true,
+              },
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `*Critical Issue:* A marketplace proposal cannot execute due to insufficient ADA in the treasury wallet.`,
+              },
+            },
+            {
+              type: 'section',
+              fields: [
+                {
+                  type: 'mrkdwn',
+                  text: `*Vault:*\n${vaultName}`,
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*Vault ID:*\n\`${data.vaultId || 'Unknown'}\``,
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*Proposal:*\n${proposalTitle}`,
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*Proposal ID:*\n\`${proposalId}\``,
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*Required ADA:*\n${requiredAda} ADA minimum`,
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*Proposal Type:*\n${data.proposalType || 'Unknown'}`,
+                },
+              ],
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `*Treasury Address:*\n\`${treasuryAddress}\``,
+              },
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `*Action Required:*\nThe treasury wallet needs to be funded with at least ${requiredAda} ADA to execute this marketplace operation. The proposal will automatically retry every 5 minutes.`,
+              },
+            },
+            {
+              type: 'divider',
+            },
+            {
+              type: 'context',
+              elements: [
+                {
+                  type: 'mrkdwn',
+                  text: `*Timestamp:* ${timestamp} | *Environment:* Production`,
+                },
+              ],
+            },
+          ],
         };
       }
 

--- a/src/modules/alerts/alerts.service.ts
+++ b/src/modules/alerts/alerts.service.ts
@@ -663,7 +663,10 @@ export class AlertsService {
             {
               type: 'context',
               elements: [
+                {
+                  type: 'mrkdwn',
                   text: `*Timestamp:* ${timestamp} | *Environment:* ${this.nodeEnv || 'unknown'}`,
+                },
               ],
             },
           ],

--- a/src/modules/distribution/automated-distribution.service.ts
+++ b/src/modules/distribution/automated-distribution.service.ts
@@ -12,7 +12,7 @@ import {
 
 import { Claim } from '@/database/claim.entity';
 import { Vault } from '@/database/vault.entity';
-import { GovernanceService } from '@/modules/vaults/phase-management/governance/governance.service';
+import GovernanceService from '@/modules/vaults/phase-management/governance/governance.service';
 import { BlockchainService } from '@/modules/vaults/processing-tx/onchain/blockchain.service';
 import { VyfiService } from '@/modules/vyfi/vyfi.service';
 import { ClaimStatus, ClaimType } from '@/types/claim.types';

--- a/src/modules/notification/listeners/notification-events.listener.ts
+++ b/src/modules/notification/listeners/notification-events.listener.ts
@@ -422,6 +422,78 @@ export class NotificationEventsListener {
     );
   }
 
+  @OnEvent('offer.accepted')
+  async handleOfferAccepted(event: {
+    vaultId: string;
+    vaultName: string;
+    assetNames: string[];
+    tokenHolderIds: string[];
+  }): Promise<void> {
+    if (event.tokenHolderIds.length === 0) {
+      this.logger.debug(`No token holders to notify for accepted offers in vault ${event.vaultName}`);
+      return;
+    }
+
+    const assetList =
+      event.assetNames.length === 1
+        ? event.assetNames[0]
+        : event.assetNames.length === 2
+          ? event.assetNames.join(' and ')
+          : `${event.assetNames.slice(0, -1).join(', ')}, and ${event.assetNames[event.assetNames.length - 1]}`;
+
+    const pluralized = event.assetNames.length === 1 ? 'offer has' : 'offers have';
+
+    await this.notificationService.sendBulkNotification(
+      {
+        title: `NFT ${event.assetNames.length === 1 ? 'Offer' : 'Offers'} Accepted`,
+        description: `${pluralized} been accepted for ${assetList} in vault ${event.vaultName}. The NFT${event.assetNames.length === 1 ? ' is' : 's are'} now in the treasury wallet.`,
+        vaultId: event.vaultId,
+        vaultName: event.vaultName,
+      },
+      event.tokenHolderIds
+    );
+
+    this.logger.log(
+      `Sent offer accepted notification to ${event.tokenHolderIds.length} token holders for vault ${event.vaultName}`
+    );
+  }
+
+  @OnEvent('offer.cancelled')
+  async handleOfferCancelled(event: {
+    vaultId: string;
+    vaultName: string;
+    assetNames: string[];
+    tokenHolderIds: string[];
+  }): Promise<void> {
+    if (event.tokenHolderIds.length === 0) {
+      this.logger.debug(`No token holders to notify for cancelled offers in vault ${event.vaultName}`);
+      return;
+    }
+
+    const assetList =
+      event.assetNames.length === 1
+        ? event.assetNames[0]
+        : event.assetNames.length === 2
+          ? event.assetNames.join(' and ')
+          : `${event.assetNames.slice(0, -1).join(', ')}, and ${event.assetNames[event.assetNames.length - 1]}`;
+
+    const pluralized = event.assetNames.length === 1 ? 'offer was' : 'offers were';
+
+    await this.notificationService.sendBulkNotification(
+      {
+        title: `NFT ${event.assetNames.length === 1 ? 'Offer' : 'Offers'} Cancelled`,
+        description: `The ${pluralized} cancelled or rejected for ${assetList} in vault ${event.vaultName}.`,
+        vaultId: event.vaultId,
+        vaultName: event.vaultName,
+      },
+      event.tokenHolderIds
+    );
+
+    this.logger.log(
+      `Sent offer cancelled notification to ${event.tokenHolderIds.length} token holders for vault ${event.vaultName}`
+    );
+  }
+
   // MILESTONE NOTIFICATIONS
   @OnEvent('milestone.tvl_reached') // Haven`t added
   async handleTVLMilestone(event: {

--- a/src/modules/vaults/assets/assets.module.ts
+++ b/src/modules/vaults/assets/assets.module.ts
@@ -13,12 +13,14 @@ import { User } from '@/database/user.entity';
 import { Vault } from '@/database/vault.entity';
 import { DexHunterPricingModule } from '@/modules/dexhunter/dexhunter-pricing.module';
 import { GoogleCloudStorageModule } from '@/modules/google_cloud/google_bucket/bucket.module';
+import { SnapshotModule } from '@/modules/vaults/phase-management/governance/snapshot.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Asset, Vault, Transaction, User, Claim, Snapshot, Market]),
     GoogleCloudStorageModule,
     DexHunterPricingModule,
+    SnapshotModule,
   ],
   controllers: [AssetsController],
   providers: [AssetsService],

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -737,6 +737,7 @@ export class AssetsService {
       {
         status: AssetStatus.EXTRACTED,
         origin_type: AssetOriginType.BOUGHT,
+        updated_at: new Date(),
         ...this.clearOfferListingFields(),
       }
     );

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -696,6 +696,56 @@ export class AssetsService {
     );
   }
 
+  private clearOfferListingFields(): {
+    listing_market: null;
+    listing_price: null;
+    listing_tx_hash: null;
+    listed_at: null;
+  } {
+    return {
+      listing_market: null,
+      listing_price: null,
+      listing_tx_hash: null,
+      listed_at: null,
+    };
+  }
+
+  /** Offer accepted on WayUp — NFT is in treasury. */
+  async markOffersAsAccepted(assetIds: string[]): Promise<void> {
+    if (assetIds.length === 0) return;
+
+    await this.assetsRepository.update(
+      {
+        id: In(assetIds),
+        status: AssetStatus.OFFERED,
+        origin_type: AssetOriginType.OFFERED,
+        deleted: false,
+      },
+      {
+        status: AssetStatus.EXTRACTED,
+        origin_type: AssetOriginType.BOUGHT,
+        ...this.clearOfferListingFields(),
+      }
+    );
+  }
+
+  /** Offer cancelled or rejected on WayUp (or via governance CANCEL_OFFER). */
+  async markOffersAsCancelled(assetIds: string[]): Promise<void> {
+    if (assetIds.length === 0) return;
+
+    await this.assetsRepository.update(
+      {
+        id: In(assetIds),
+        status: AssetStatus.OFFERED,
+        deleted: false,
+      },
+      {
+        status: AssetStatus.CANCEL_OFFER,
+        ...this.clearOfferListingFields(),
+      }
+    );
+  }
+
   /**
    * Mark multiple assets as listed with individual listing prices
    */
@@ -827,6 +877,7 @@ export class AssetsService {
     floorPrice: number;
     metadata?: any;
     status?: AssetStatus;
+    originType?: AssetOriginType;
   }): Promise<Asset> {
     const vault = await this.vaultsRepository.findOne({ where: { id: params.vaultId } });
 
@@ -844,6 +895,9 @@ export class AssetsService {
       }
     }
 
+    const originType = params.originType ?? AssetOriginType.BOUGHT;
+    const defaultStatus = originType === AssetOriginType.OFFERED ? AssetStatus.OFFERED : AssetStatus.EXTRACTED;
+
     const asset = this.assetsRepository.create({
       vault,
       policy_id: params.policyId,
@@ -853,8 +907,8 @@ export class AssetsService {
       type: AssetType.NFT,
       quantity: 1,
       floor_price: params.floorPrice,
-      status: params.status ?? AssetStatus.LOCKED,
-      origin_type: AssetOriginType.BOUGHT,
+      status: params.status ?? defaultStatus,
+      origin_type: originType,
       added_by: null,
       metadata: params.metadata ?? null,
     });

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -728,6 +728,20 @@ export class AssetsService {
   async markOffersAsAccepted(assetIds: string[]): Promise<void> {
     if (assetIds.length === 0) return;
 
+    // First, fetch the assets with their prices and vault info before updating
+    const assets = await this.assetsRepository.find({
+      where: {
+        id: In(assetIds),
+        status: AssetStatus.OFFERED,
+        origin_type: AssetOriginType.OFFERED,
+        deleted: false,
+      },
+      select: ['id', 'vault_id', 'listing_price', 'floor_price'],
+    });
+
+    if (assets.length === 0) return;
+
+    // Update asset statuses
     await this.assetsRepository.update(
       {
         id: In(assetIds),
@@ -745,6 +759,56 @@ export class AssetsService {
         listed_at: null,
       }
     );
+
+    // Try to update vault costs, but don't fail the whole operation if this fails
+    try {
+      // Group assets by vault and calculate total cost per vault
+      const vaultCosts = new Map<string, number>();
+
+      for (const asset of assets) {
+        if (!asset.vault_id) continue;
+
+        // Use listing_price (offer price) or fall back to floor_price
+        const price = asset.listing_price ?? asset.floor_price ?? 0;
+        if (price <= 0) continue; // Skip assets without valid pricing
+
+        const currentTotal = vaultCosts.get(asset.vault_id) ?? 0;
+        vaultCosts.set(asset.vault_id, currentTotal + price);
+      }
+
+      if (vaultCosts.size === 0) return; // No vaults with valid pricing
+
+      // Get current ADA price in USD
+      const adaPriceUsd = await this.priceService.getAdaPrice();
+
+      // Update each vault's cost fields to reflect the newly acquired assets
+      for (const [vaultId, totalCostAda] of vaultCosts.entries()) {
+        const totalCostUsd = totalCostAda * adaPriceUsd;
+
+        await this.vaultsRepository
+          .createQueryBuilder()
+          .update(Vault)
+          .set({
+            total_assets_cost_ada: () => `total_assets_cost_ada + ${totalCostAda}`,
+            total_assets_cost_usd: () => `total_assets_cost_usd + ${totalCostUsd}`,
+            last_valuation_update: new Date(),
+          })
+          .where('id = :vaultId', { vaultId })
+          .execute();
+
+        const assetCount = assets.filter(a => a.vault_id === vaultId).length;
+        this.logger.log(
+          `Updated vault ${vaultId} costs: +${totalCostAda.toFixed(2)} ADA (+${totalCostUsd.toFixed(2)} USD) from ${assetCount} accepted offer(s)`
+        );
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to update vault costs for accepted offers: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
+      // Asset status updates already completed successfully, so we just log the error
+    }
   }
 
   /** Offer cancelled or rejected on WayUp by NFT owner (or via governance CANCEL_OFFER). */

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -750,10 +750,13 @@ export class AssetsService {
       {
         id: In(assetIds),
         status: AssetStatus.OFFERED,
+        origin_type: AssetOriginType.OFFERED,
         deleted: false,
       },
       {
         status: AssetStatus.CANCEL_OFFER,
+        deleted: true,
+        updated_at: new Date(),
         ...this.clearOfferListingFields(),
       }
     );

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -20,6 +20,7 @@ import { DexHunterPricingService } from '@/modules/dexhunter/dexhunter-pricing.s
 import { SystemSettingsService } from '@/modules/globals/system-settings';
 import { GoogleCloudStorageService } from '@/modules/google_cloud/google_bucket/bucket.service';
 import { PriceService } from '@/modules/price/price.service';
+import { SnapshotService } from '@/modules/vaults/phase-management/governance/snapshot.service';
 import { AssetOriginType, AssetStatus, AssetType } from '@/types/asset.types';
 import { VaultStatus } from '@/types/vault.types';
 
@@ -69,7 +70,8 @@ export class AssetsService {
     private readonly priceService: PriceService,
     private readonly dexHunterPricingService: DexHunterPricingService,
     private readonly systemSettingsService: SystemSettingsService,
-    private readonly gcsService: GoogleCloudStorageService
+    private readonly gcsService: GoogleCloudStorageService,
+    private readonly snapshotService: SnapshotService
   ) {
     this.VLRM_HEX_ASSET_NAME = this.configService.get<string>('VLRM_HEX_ASSET_NAME');
     this.VLRM_POLICY_ID = this.configService.get<string>('VLRM_POLICY_ID');
@@ -736,7 +738,8 @@ export class AssetsService {
         origin_type: AssetOriginType.OFFERED,
         deleted: false,
       },
-      select: ['id', 'vault_id', 'listing_price', 'floor_price'],
+      select: ['id', 'vault_id', 'listing_price', 'floor_price', 'name'],
+      relations: ['vault'],
     });
 
     if (assets.length === 0) return;
@@ -809,11 +812,26 @@ export class AssetsService {
       );
       // Asset status updates already completed successfully, so we just log the error
     }
+
+    // Emit events for accepted offers grouped by vault
+    await this.emitOfferStatusEvents(assets, 'offer.accepted');
   }
 
   /** Offer cancelled or rejected on WayUp by NFT owner (or via governance CANCEL_OFFER). */
   async markOffersAsCancelled(assetIds: string[]): Promise<void> {
     if (assetIds.length === 0) return;
+
+    // Fetch assets with vault info before updating for notification
+    const assets = await this.assetsRepository.find({
+      where: {
+        id: In(assetIds),
+        status: AssetStatus.OFFERED,
+        origin_type: AssetOriginType.OFFERED,
+        deleted: false,
+      },
+      select: ['id', 'vault_id', 'name'],
+      relations: ['vault'],
+    });
 
     await this.assetsRepository.update(
       {
@@ -832,6 +850,9 @@ export class AssetsService {
         listed_at: null,
       }
     );
+
+    // Emit events for cancelled offers grouped by vault
+    await this.emitOfferStatusEvents(assets, 'offer.cancelled');
   }
 
   /**
@@ -1017,5 +1038,51 @@ export class AssetsService {
     asset.updated_at = new Date();
 
     await this.assetsRepository.save(asset);
+  }
+
+  /**
+   * Group assets by vault and emit events with token holder notifications
+   * @param assets Assets with vault relations loaded
+   * @param eventName Event name to emit (e.g., 'offer.accepted', 'offer.cancelled')
+   */
+  private async emitOfferStatusEvents(
+    assets: Array<{ vault_id?: string; vault?: { name: string }; name?: string }>,
+    eventName: 'offer.accepted' | 'offer.cancelled'
+  ): Promise<void> {
+    try {
+      const vaultGroups = new Map<string, { vaultName: string; assetNames: string[] }>();
+
+      for (const asset of assets) {
+        if (!asset.vault_id || !asset.vault) continue;
+
+        const group = vaultGroups.get(asset.vault_id);
+        if (group) {
+          group.assetNames.push(asset.name || 'Unknown NFT');
+        } else {
+          vaultGroups.set(asset.vault_id, {
+            vaultName: asset.vault.name,
+            assetNames: [asset.name || 'Unknown NFT'],
+          });
+        }
+      }
+
+      // Emit one event per vault with all offers
+      for (const [vaultId, { vaultName, assetNames }] of vaultGroups.entries()) {
+        const tokenHolderIds = await this.snapshotService.getTokenHolderIdsFromLatestSnapshot(vaultId);
+
+        this.eventEmitter.emit(eventName, {
+          vaultId,
+          vaultName,
+          assetNames,
+          tokenHolderIds,
+        });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to emit ${eventName} events: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
+    }
   }
 }

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -826,6 +826,10 @@ export class AssetsService {
         status: AssetStatus.CANCEL_OFFER,
         deleted: true,
         updated_at: new Date(),
+        listing_market: null,
+        listing_price: null,
+        listing_tx_hash: null,
+        listed_at: null,
       }
     );
   }

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -30,6 +30,27 @@ export class AssetsService {
   private readonly VLRM_POLICY_ID: string;
   private readonly isMainnet: boolean;
 
+  /** Origin types shown in vault assets list (contributed, bought, fee, and offered assets) */
+  private readonly VAULT_ASSETS_ORIGIN_TYPES = [
+    AssetOriginType.CONTRIBUTED,
+    AssetOriginType.BOUGHT,
+    AssetOriginType.FEE,
+    AssetOriginType.OFFERED,
+  ];
+
+  /** Asset statuses shown in vault assets list (all active states) */
+  private readonly VAULT_ASSETS_STATUSES = [
+    AssetStatus.PENDING,
+    AssetStatus.LOCKED,
+    AssetStatus.EXTRACTED,
+    AssetStatus.RELEASED,
+    AssetStatus.LISTED,
+    AssetStatus.OFFERED,
+  ];
+
+  /** Asset statuses shown in acquired assets list (locked, released, and distributed) */
+  private readonly ACQUIRED_ASSETS_STATUSES = [AssetStatus.LOCKED, AssetStatus.RELEASED, AssetStatus.DISTRIBUTED];
+
   constructor(
     @InjectRepository(Asset)
     private readonly assetsRepository: Repository<Asset>,
@@ -228,16 +249,10 @@ export class AssetsService {
       ])
       .where('asset.vault_id = :vaultId', { vaultId })
       .andWhere('asset.origin_type IN (:...originTypes)', {
-        originTypes: [AssetOriginType.CONTRIBUTED, AssetOriginType.BOUGHT, AssetOriginType.FEE],
+        originTypes: this.VAULT_ASSETS_ORIGIN_TYPES,
       })
       .andWhere('asset.status IN (:...statuses)', {
-        statuses: [
-          AssetStatus.PENDING,
-          AssetStatus.LOCKED,
-          AssetStatus.EXTRACTED,
-          AssetStatus.RELEASED,
-          AssetStatus.LISTED,
-        ],
+        statuses: this.VAULT_ASSETS_STATUSES,
       });
 
     if (search) {
@@ -388,7 +403,7 @@ export class AssetsService {
         originType: AssetOriginType.ACQUIRED,
       })
       .andWhere('asset.status IN (:...statuses)', {
-        statuses: [AssetStatus.LOCKED, AssetStatus.RELEASED, AssetStatus.DISTRIBUTED],
+        statuses: this.ACQUIRED_ASSETS_STATUSES,
       });
 
     if (search) {

--- a/src/modules/vaults/assets/assets.service.ts
+++ b/src/modules/vaults/assets/assets.service.ts
@@ -709,21 +709,7 @@ export class AssetsService {
     );
   }
 
-  private clearOfferListingFields(): {
-    listing_market: null;
-    listing_price: null;
-    listing_tx_hash: null;
-    listed_at: null;
-  } {
-    return {
-      listing_market: null,
-      listing_price: null,
-      listing_tx_hash: null,
-      listed_at: null,
-    };
-  }
-
-  /** Offer accepted on WayUp — NFT is in treasury. */
+  /** Offer accepted on WayUp by NFT owner — NFT is in treasury. */
   async markOffersAsAccepted(assetIds: string[]): Promise<void> {
     if (assetIds.length === 0) return;
 
@@ -738,12 +724,15 @@ export class AssetsService {
         status: AssetStatus.EXTRACTED,
         origin_type: AssetOriginType.BOUGHT,
         updated_at: new Date(),
-        ...this.clearOfferListingFields(),
+        listing_market: null,
+        listing_price: null,
+        listing_tx_hash: null,
+        listed_at: null,
       }
     );
   }
 
-  /** Offer cancelled or rejected on WayUp (or via governance CANCEL_OFFER). */
+  /** Offer cancelled or rejected on WayUp by NFT owner (or via governance CANCEL_OFFER). */
   async markOffersAsCancelled(assetIds: string[]): Promise<void> {
     if (assetIds.length === 0) return;
 
@@ -758,7 +747,6 @@ export class AssetsService {
         status: AssetStatus.CANCEL_OFFER,
         deleted: true,
         updated_at: new Date(),
-        ...this.clearOfferListingFields(),
       }
     );
   }

--- a/src/modules/vaults/phase-management/governance/dto/asset-metadata.res.ts
+++ b/src/modules/vaults/phase-management/governance/dto/asset-metadata.res.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AssetMetadataRes {
+  @ApiProperty({
+    description: 'Display name of the asset from on-chain metadata',
+    example: 'SpaceBud #5452',
+  })
+  displayName: string;
+}

--- a/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
+++ b/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
@@ -101,6 +101,7 @@ export class MarketplaceAssetDto {
 export enum ExecType {
   BUY = 'BUY',
   OFFER = 'OFFER',
+  CANCEL_OFFER = 'CANCEL_OFFER',
   SELL = 'SELL',
   UNLIST = 'UNLIST',
   UPDATE_LISTING = 'UPDATE_LISTING',
@@ -122,7 +123,7 @@ export class MarketplaceActionDto {
   assetId: string;
 
   @ApiProperty({
-    description: 'Action type: BUY, OFFER, SELL, UNLIST, or UPDATE_LISTING',
+    description: 'Action type: BUY, OFFER, CANCEL_OFFER, SELL, UNLIST, or UPDATE_LISTING',
     enum: ExecType,
   })
   @IsEnum(ExecType)
@@ -242,7 +243,8 @@ export class MarketplaceActionDto {
   }>;
 
   @ApiProperty({
-    description: 'NFT metadata snapshot at proposal creation time (auto-populated for BUY and OFFER actions)',
+    description:
+      'NFT metadata snapshot at proposal creation time (auto-populated for BUY, OFFER, and CANCEL_OFFER actions)',
     required: false,
   })
   @IsOptional()
@@ -364,7 +366,7 @@ export class CreateProposalReq {
   distributionLovelaceAmount?: number;
 
   @ApiProperty({
-    description: 'Marketplace actions for marketplace proposals (buy, offer, sell, unlist, update)',
+    description: 'Marketplace actions for marketplace proposals (buy, offer, cancel offer, sell, unlist, update)',
     type: [MarketplaceActionDto],
     required: false,
   })

--- a/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
+++ b/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
@@ -122,14 +122,14 @@ export class MarketplaceActionDto {
   assetId: string;
 
   @ApiProperty({
-    description: 'Action type: BUY, SELL, UNLIST, or UPDATE_LISTING',
+    description: 'Action type: BUY, OFFER, SELL, UNLIST, or UPDATE_LISTING',
     enum: ExecType,
   })
   @IsEnum(ExecType)
   exec: ExecType;
 
   @ApiProperty({
-    description: 'Asset name to buy',
+    description: 'NFT display name for WayUp lookup (required for BUY and OFFER)',
     required: false,
   })
   @IsOptional()
@@ -172,7 +172,7 @@ export class MarketplaceActionDto {
   method?: MethodType;
 
   @ApiProperty({
-    description: 'Price in ADA (for SELL)',
+    description: 'Price in ADA: listing price (SELL), max willing to pay (BUY), or offer amount (OFFER)',
     required: false,
   })
   @IsOptional()
@@ -242,7 +242,7 @@ export class MarketplaceActionDto {
   }>;
 
   @ApiProperty({
-    description: 'NFT metadata snapshot at proposal creation time (auto-populated for BUY actions)',
+    description: 'NFT metadata snapshot at proposal creation time (auto-populated for BUY and OFFER actions)',
     required: false,
   })
   @IsOptional()
@@ -364,7 +364,7 @@ export class CreateProposalReq {
   distributionLovelaceAmount?: number;
 
   @ApiProperty({
-    description: 'Marketplace actions for buy/sell proposals',
+    description: 'Marketplace actions for marketplace proposals (buy, offer, sell, unlist, update)',
     type: [MarketplaceActionDto],
     required: false,
   })

--- a/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
+++ b/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
@@ -148,15 +148,16 @@ export class MarketplaceActionDto {
   @IsString()
   displayName?: string;
 
-  // ===== SELL fields =====
+  // ===== SWAP field (DexHunter only) =====
   @ApiProperty({
-    description: 'Quantity to buy/sell',
+    description: 'Quantity to swap (only used for DexHunter swaps, not for NFT sells)',
     required: false,
   })
   @IsOptional()
   @IsString()
   quantity?: string;
 
+  // ===== SELL fields =====
   @ApiProperty({
     description: 'Market or List sale type',
     enum: SellType,

--- a/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
+++ b/src/modules/vaults/phase-management/governance/dto/create-proposal.req.ts
@@ -140,6 +140,14 @@ export class MarketplaceActionDto {
   @IsString()
   assetName?: string;
 
+  @ApiProperty({
+    description: 'Asset display name from on-chain metadata (auto-fetched from Blockfrost)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  displayName?: string;
+
   // ===== SELL fields =====
   @ApiProperty({
     description: 'Quantity to buy/sell',

--- a/src/modules/vaults/phase-management/governance/dto/get-assets.dto.ts
+++ b/src/modules/vaults/phase-management/governance/dto/get-assets.dto.ts
@@ -22,6 +22,10 @@ export class AssetBuySellDto {
   @Expose()
   policy_id: string;
 
+  @ApiProperty({ description: 'Asset ID (hex-encoded asset name)' })
+  @Expose()
+  asset_id: string;
+
   @ApiProperty({ description: 'Asset quantity' })
   @Expose()
   quantity: string;
@@ -66,6 +70,23 @@ export class AssetBuySellDto {
   @ApiPropertyOptional({ description: 'Date when asset was listed' })
   @Expose()
   listed_at?: Date;
+
+  // Computed fields for offer details
+  @ApiPropertyOptional({ description: 'Formatted listing price with ADA suffix', example: '6.00 ADA' })
+  @Expose()
+  @Transform(({ obj }) => {
+    if (!obj.listing_price) return null;
+    return `${parseFloat(obj.listing_price).toFixed(2)} ADA`;
+  })
+  formattedListingPrice?: string;
+
+  @ApiPropertyOptional({ description: 'Formatted floor price with ADA suffix', example: '6 ADA' })
+  @Expose()
+  @Transform(({ obj }) => {
+    if (!obj.floor_price) return null;
+    return `${obj.floor_price} ADA`;
+  })
+  formattedFloorPrice?: string;
 }
 
 // LP Pool DTOs for Termination

--- a/src/modules/vaults/phase-management/governance/dto/get-offers-to-cancel.dto.ts
+++ b/src/modules/vaults/phase-management/governance/dto/get-offers-to-cancel.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Transform } from 'class-transformer';
+import { IsOptional, IsString } from 'class-validator';
+
+import { PaginationDto } from '@/modules/vaults/dto/pagination.dto';
+import { AssetBuySellDto } from '@/modules/vaults/phase-management/governance/dto/get-assets.dto';
+
+export class GetOffersToCancelDto extends PaginationDto {
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Search by NFT name, policy ID, or asset ID (hex)',
+  })
+  @Expose()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  search?: string;
+}
+
+export class PaginatedOffersToCancelResponseDto {
+  @ApiProperty({ type: [AssetBuySellDto], description: 'Offers that can be cancelled via CANCEL_OFFER proposal' })
+  items: AssetBuySellDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty()
+  totalPages: number;
+}

--- a/src/modules/vaults/phase-management/governance/dto/get-proposal-detail.res.ts
+++ b/src/modules/vaults/phase-management/governance/dto/get-proposal-detail.res.ts
@@ -215,7 +215,7 @@ export class MarketplaceActionDetailDto {
 
   @Expose()
   @ApiProperty({
-    description: 'Action type: BUY, OFFER, SELL, UNLIST, or UPDATE_LISTING',
+    description: 'Action type: BUY, OFFER, CANCEL_OFFER, SELL, UNLIST, or UPDATE_LISTING',
     example: 'SELL',
   })
   exec: string;

--- a/src/modules/vaults/phase-management/governance/dto/get-proposal-detail.res.ts
+++ b/src/modules/vaults/phase-management/governance/dto/get-proposal-detail.res.ts
@@ -214,7 +214,10 @@ export class MarketplaceActionDetailDto {
   assetId: string;
 
   @Expose()
-  @ApiProperty({ description: 'Action type: BUY, SELL, UNLIST, or UPDATE_LISTING', example: 'SELL' })
+  @ApiProperty({
+    description: 'Action type: BUY, OFFER, SELL, UNLIST, or UPDATE_LISTING',
+    example: 'SELL',
+  })
   exec: string;
 
   @Expose()

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -765,7 +765,7 @@ export class GovernanceExecutionService {
       const assetsToExtract: string[] = [];
       const unlistings: { policyId: string; assetName: string; txHashIndex: string }[] = [];
       const unlistedAssetIds: string[] = [];
-      const unlistOffers: { policyId: string; txHashIndex: string }[] = [];
+      const unlistOffers: { policyId: string; assetName: string; txHashIndex: string }[] = [];
       const cancelledOfferAssetIds: string[] = [];
       const updates: { policyId: string; assetName: string; txHashIndex: string; newPriceAda: number }[] = [];
       const updateAssetInfos: { assetId: string; newPrice: number }[] = [];
@@ -941,7 +941,7 @@ export class GovernanceExecutionService {
           continue;
         }
 
-        unlistOffers.push({ policyId: asset.policy_id, txHashIndex });
+        unlistOffers.push({ policyId: asset.policy_id, assetName: asset.asset_id, txHashIndex });
         cancelledOfferAssetIds.push(option.assetId);
       }
 

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -737,6 +737,7 @@ export class GovernanceExecutionService {
     const dbAssetIds = [
       ...(operations.sells?.map(opt => opt.assetId) || []),
       ...(operations.unlists?.map(opt => opt.assetId) || []),
+      ...(operations.cancelOffers?.map(opt => opt.assetId) || []),
       ...(operations.updates?.map(opt => opt.assetId) || []),
     ];
 
@@ -759,7 +760,7 @@ export class GovernanceExecutionService {
     try {
       this.logger.log(
         `Processing ${operations.sells.length} sell(s), ${operations.buys.length} buy(s), ` +
-          `${operations.offers.length} offer(s), ${operations.unlists.length} unlist(s), ` +
+          `${operations.offers.length} offer(s), ${operations.cancelOffers.length} cancel-offer(s), ${operations.unlists.length} unlist(s), ` +
           `and ${operations.updates.length} update(s) for WayUp`
       );
 
@@ -769,6 +770,8 @@ export class GovernanceExecutionService {
       const assetsToExtract: string[] = [];
       const unlistings: { policyId: string; assetName: string; txHashIndex: string }[] = [];
       const unlistedAssetIds: string[] = [];
+      const unlistOffers: { policyId: string; txHashIndex: string }[] = [];
+      const cancelledOfferAssetIds: string[] = [];
       const updates: { policyId: string; assetName: string; txHashIndex: string; newPriceAda: number }[] = [];
       const updateAssetInfos: { assetId: string; newPrice: number }[] = [];
       const purchases: {
@@ -790,10 +793,18 @@ export class GovernanceExecutionService {
         metadata?: any;
       }[] = [];
 
-      const skipped: { sells: string[]; buys: string[]; offers: string[]; unlists: string[]; updates: string[] } = {
+      const skipped: {
+        sells: string[];
+        buys: string[];
+        offers: string[];
+        cancelOffers: string[];
+        unlists: string[];
+        updates: string[];
+      } = {
         sells: [],
         buys: [],
         offers: [],
+        cancelOffers: [],
         unlists: [],
         updates: [],
       };
@@ -855,6 +866,26 @@ export class GovernanceExecutionService {
 
         unlistings.push({ policyId: asset.policy_id, assetName: asset.asset_id, txHashIndex });
         unlistedAssetIds.push(option.assetId);
+      }
+
+      // Process CANCEL_OFFER operations
+      for (const option of operations.cancelOffers) {
+        const asset = assetMap.get(option.assetId);
+        if (!asset) {
+          this.logger.warn(`Asset not found for cancel-offer assetId: ${option.assetId}`);
+          skipped.cancelOffers.push(option.assetId);
+          continue;
+        }
+
+        const txHashIndex = asset.listing_tx_hash;
+        if (!txHashIndex) {
+          this.logger.warn(`Cannot cancel offer - missing listing_tx_hash for ${asset.name}`);
+          skipped.cancelOffers.push(asset.name || option.assetId);
+          continue;
+        }
+
+        unlistOffers.push({ policyId: asset.policy_id, txHashIndex });
+        cancelledOfferAssetIds.push(option.assetId);
       }
 
       // Process UPDATE_LISTING operations
@@ -1031,6 +1062,12 @@ export class GovernanceExecutionService {
         await this.rejectMarketplaceProposal(proposal, reason, 'PROPOSAL_REJECTED_OFFER_OPERATION_SKIPPED');
       }
 
+      // If any cancel-offer was requested but skipped — reject entire proposal
+      if (operations.cancelOffers.length > 0 && skipped.cancelOffers.length > 0) {
+        const reason = `Cannot execute all cancel-offer operations: ${skipped.cancelOffers.join(', ')}`;
+        await this.rejectMarketplaceProposal(proposal, reason, 'PROPOSAL_REJECTED_OFFER_OPERATION_SKIPPED');
+      }
+
       // Log skipped operations
       if (skipped.sells.length > 0) {
         this.logger.warn(`Skipped ${skipped.sells.length} sell(s): ${skipped.sells.join(', ')}`);
@@ -1041,6 +1078,9 @@ export class GovernanceExecutionService {
       if (skipped.offers.length > 0) {
         this.logger.warn(`Skipped ${skipped.offers.length} offer(s): ${skipped.offers.join(', ')}`);
       }
+      if (skipped.cancelOffers.length > 0) {
+        this.logger.warn(`Skipped ${skipped.cancelOffers.length} cancel-offer(s): ${skipped.cancelOffers.join(', ')}`);
+      }
       if (skipped.unlists.length > 0) {
         this.logger.warn(`Skipped ${skipped.unlists.length} unlist(s): ${skipped.unlists.join(', ')}`);
       }
@@ -1050,13 +1090,19 @@ export class GovernanceExecutionService {
 
       // Check if there are any valid operations
       const hasOperations =
-        listings.length > 0 || unlistings.length > 0 || updates.length > 0 || purchases.length > 0 || offers.length > 0;
+        listings.length > 0 ||
+        unlistings.length > 0 ||
+        unlistOffers.length > 0 ||
+        updates.length > 0 ||
+        purchases.length > 0 ||
+        offers.length > 0;
 
       if (!hasOperations) {
         const totalSkipped =
           skipped.sells.length +
           skipped.buys.length +
           skipped.offers.length +
+          skipped.cancelOffers.length +
           skipped.unlists.length +
           skipped.updates.length;
         let reason = 'No valid marketplace operations to execute';
@@ -1077,6 +1123,9 @@ export class GovernanceExecutionService {
           }
           if (skipped.offers.length > 0) {
             reasons.push(`${skipped.offers.length} asset(s) could not be offered on`);
+          }
+          if (skipped.cancelOffers.length > 0) {
+            reasons.push(`${skipped.cancelOffers.length} offer(s) could not be cancelled`);
           }
           reason = `All operations skipped: ${reasons.join(', ')}`;
         }
@@ -1159,12 +1208,13 @@ export class GovernanceExecutionService {
       // STEP 2: Execute all marketplace actions in a single atomic transaction
       this.logger.log(
         `Executing combined marketplace actions: ${listings.length} listings, ${unlistings.length} unlistings, ` +
-          `${updates.length} updates, ${purchases.length} purchases, ${offers.length} offers`
+          `${unlistOffers.length} cancel-offers, ${updates.length} updates, ${purchases.length} purchases, ${offers.length} offers`
       );
 
       const result = await this.wayUpService.executeCombinedMarketplaceActions(proposal.vaultId, {
         listings: listings.length > 0 ? listings : undefined,
         unlistings: unlistings.length > 0 ? unlistings : undefined,
+        unlistOffers: unlistOffers.length > 0 ? unlistOffers : undefined,
         updates: updates.length > 0 ? updates : undefined,
         purchases: purchases.length > 0 ? purchases : undefined,
         offers: offers.length > 0 ? offers : undefined,
@@ -1198,6 +1248,25 @@ export class GovernanceExecutionService {
           this.logger.log(`Marked ${unlistedAssetIds.length} asset(s) as EXTRACTED (unlisted)`);
         } catch (statusError) {
           this.logger.warn(`Failed to update asset statuses to EXTRACTED: ${statusError.message}`);
+        }
+      }
+
+      // Update cancelled offers
+      if (unlistOffers.length > 0) {
+        try {
+          await this.assetRepository.update(
+            { id: In(cancelledOfferAssetIds) },
+            {
+              status: AssetStatus.EXTRACTED,
+              listing_tx_hash: null,
+              listing_market: null,
+              listing_price: null,
+              listed_at: null,
+            }
+          );
+          this.logger.log(`Marked ${cancelledOfferAssetIds.length} asset(s) as EXTRACTED (offer cancelled)`);
+        } catch (statusError) {
+          this.logger.warn(`Failed to update cancelled offer asset statuses: ${statusError.message}`);
         }
       }
 
@@ -1244,7 +1313,7 @@ export class GovernanceExecutionService {
       if (offers.length > 0) {
         for (const offer of offers) {
           try {
-            await this.assetsService.recordBoughtAsset({
+            const offeredAsset = await this.assetsService.recordBoughtAsset({
               vaultId: proposal.vaultId,
               policyId: offer.policyId,
               assetId: offer.assetName,
@@ -1254,6 +1323,15 @@ export class GovernanceExecutionService {
               metadata: offer.metadata,
               status: AssetStatus.OFFERED,
             });
+            await this.assetRepository.update(
+              { id: offeredAsset.id },
+              {
+                listing_market: 'wayup',
+                listing_price: offer.priceAda,
+                listing_tx_hash: result.txHash,
+                listed_at: new Date(),
+              }
+            );
             this.logger.log(`Recorded offered asset "${offer.name}" (${offer.policyId}) to vault ${proposal.vaultId}`);
           } catch (recordError) {
             this.logger.warn(`Failed to record offered asset "${offer.name}": ${recordError.message}`);
@@ -1749,6 +1827,7 @@ export class GovernanceExecutionService {
       sells: MarketplaceActionDto[];
       buys: MarketplaceActionDto[];
       offers: MarketplaceActionDto[];
+      cancelOffers: MarketplaceActionDto[];
       unlists: MarketplaceActionDto[];
       updates: MarketplaceActionDto[];
     }
@@ -1759,6 +1838,7 @@ export class GovernanceExecutionService {
         sells: MarketplaceActionDto[];
         buys: MarketplaceActionDto[];
         offers: MarketplaceActionDto[];
+        cancelOffers: MarketplaceActionDto[];
         unlists: MarketplaceActionDto[];
         updates: MarketplaceActionDto[];
       }
@@ -1767,7 +1847,7 @@ export class GovernanceExecutionService {
     for (const option of options) {
       const market = (option.market || 'wayup').toLowerCase(); // Normalize to lowercase
       if (!grouped[market]) {
-        grouped[market] = { sells: [], buys: [], offers: [], unlists: [], updates: [] };
+        grouped[market] = { sells: [], buys: [], offers: [], cancelOffers: [], unlists: [], updates: [] };
       }
 
       if (option.exec === ExecType.SELL) {
@@ -1776,6 +1856,8 @@ export class GovernanceExecutionService {
         grouped[market].buys.push(option);
       } else if (option.exec === ExecType.OFFER) {
         grouped[market].offers.push(option);
+      } else if (option.exec === ExecType.CANCEL_OFFER) {
+        grouped[market].cancelOffers.push(option);
       } else if (option.exec === ExecType.UNLIST) {
         grouped[market].unlists.push(option);
       } else if (option.exec === ExecType.UPDATE_LISTING) {

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -1251,7 +1251,7 @@ export class GovernanceExecutionService {
         }
       }
 
-      // Update cancelled offers
+      // Update canceled offers
       if (unlistOffers.length > 0) {
         try {
           await this.assetRepository.update(

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -563,6 +563,14 @@ export class GovernanceExecutionService {
         return;
       }
 
+      // Check if this is a handled rejection due to skipped offer operations
+      if (error.message === 'PROPOSAL_REJECTED_OFFER_OPERATION_SKIPPED') {
+        this.logger.log(
+          `Proposal ${proposalId}: REJECTED - One or more offer operations could not be executed (NFT not found or invalid)`
+        );
+        return;
+      }
+
       // Check if this is a handled rejection due to insufficient treasury ADA for buys
       if (error.message === 'PROPOSAL_REJECTED_INSUFFICIENT_TREASURY_ADA') {
         this.logger.log(
@@ -670,6 +678,7 @@ export class GovernanceExecutionService {
         error.message === 'PROPOSAL_REJECTED_ASSETS_NOT_LOCKED' ||
         error.message === 'PROPOSAL_REJECTED_PRICE_EXCEEDED' ||
         error.message === 'PROPOSAL_REJECTED_BUY_OPERATION_SKIPPED' ||
+        error.message === 'PROPOSAL_REJECTED_OFFER_OPERATION_SKIPPED' ||
         error.message === 'PROPOSAL_REJECTED_INSUFFICIENT_TREASURY_ADA'
       ) {
         throw error;
@@ -1019,7 +1028,7 @@ export class GovernanceExecutionService {
       // If any offer was requested but skipped — reject entire proposal
       if (operations.offers.length > 0 && skipped.offers.length > 0) {
         const reason = `Cannot execute all offer operations: ${skipped.offers.join(', ')}`;
-        await this.rejectMarketplaceProposal(proposal, reason, 'PROPOSAL_REJECTED_BUY_OPERATION_SKIPPED');
+        await this.rejectMarketplaceProposal(proposal, reason, 'PROPOSAL_REJECTED_OFFER_OPERATION_SKIPPED');
       }
 
       // Log skipped operations
@@ -2112,6 +2121,8 @@ export class GovernanceExecutionService {
         'This marketplace proposal cannot be executed because all requested operations became invalid (assets already listed/unlisted or not available).',
       PRICE_EXCEEDED:
         'One or more NFTs now have a listing price higher than the maximum price specified in the proposal.',
+      OFFER_OPERATION_SKIPPED:
+        'One or more offer operations could not be executed (NFT not found on WayUp or invalid offer price).',
       CONTRACT_ERROR: 'Smart contract validation error.',
       EXECUTION_ERROR: 'Unexpected error. Review details or contact support.',
     };
@@ -2223,6 +2234,14 @@ export class GovernanceExecutionService {
       errorMessage.toLowerCase().includes('price exceeded')
     ) {
       return 'PRICE_EXCEEDED';
+    }
+
+    // Offer operations skipped at execution
+    if (
+      errorMessage.toLowerCase().includes('cannot execute all offer operations') ||
+      errorMessage.includes('PROPOSAL_REJECTED_OFFER_OPERATION_SKIPPED')
+    ) {
+      return 'OFFER_OPERATION_SKIPPED';
     }
 
     // Contract/Smart contract errors

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -19,6 +19,7 @@ import { Asset } from '@/database/asset.entity';
 import { AssetsWhitelistEntity } from '@/database/assetsWhitelist.entity';
 import { Proposal } from '@/database/proposal.entity';
 import { Vault } from '@/database/vault.entity';
+import { AlertsService } from '@/modules/alerts/alerts.service';
 import { DexHunterService } from '@/modules/dexhunter/dexhunter.service';
 import { RewardEventProducer } from '@/modules/rewards/services/reward-event-producer.service';
 import { AssetsService } from '@/modules/vaults/assets/assets.service';
@@ -72,7 +73,8 @@ export class GovernanceExecutionService {
     private readonly treasuryWalletService: TreasuryWalletService,
     private readonly governanceRefundService: GovernanceRefundService,
     private readonly rewardEventProducer: RewardEventProducer,
-    private readonly snapshotService: SnapshotService
+    private readonly snapshotService: SnapshotService,
+    private readonly alertsService: AlertsService
   ) {
     this.isMainnet = this.configService.get<string>('CARDANO_NETWORK') === 'mainnet';
     this.blockfrost = new BlockFrostAPI({
@@ -866,6 +868,7 @@ export class GovernanceExecutionService {
       // Process CANCEL_OFFER operations (verify offer still exists on WayUp before on-chain cancel)
       const treasuryAddress = proposal.vault.treasury_wallet?.treasury_address;
       let cancelOfferMarketplaceKeys: { active: Set<string>; treasury: Set<string> } | null = null;
+      let sentOffersMap: Map<string, { outputRef: string; policyId: string; assetName: string }> | null = null;
 
       if (operations.cancelOffers.length > 0 && treasuryAddress) {
         try {
@@ -877,6 +880,13 @@ export class GovernanceExecutionService {
             active: new Set(sentOffers.map(o => this.wayUpPricingService.offerAssetKey(o.policyId, o.assetName))),
             treasury: new Set(treasuryAssets.map(a => this.wayUpPricingService.offerAssetKey(a.policyId, a.assetName))),
           };
+          // Store sent offers in a map for easy lookup by asset key
+          sentOffersMap = new Map(
+            sentOffers.map(o => [
+              this.wayUpPricingService.offerAssetKey(o.policyId, o.assetName),
+              { outputRef: o.outputRef, policyId: o.policyId, assetName: o.assetName },
+            ])
+          );
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           this.logger.error(
@@ -933,13 +943,20 @@ export class GovernanceExecutionService {
           continue;
         }
 
-        // Offer is confirmed still 'active' on WayUp — require tx hash for the on-chain cancel
-        const txHashIndex = asset.listing_tx_hash;
-        if (!txHashIndex) {
-          this.logger.warn(`Cannot cancel offer - missing listing_tx_hash for ${asset.name}`);
+        // Offer is confirmed still 'active' on WayUp — get the offer output reference for on-chain cancel
+        const assetKey = this.wayUpPricingService.offerAssetKey(asset.policy_id, asset.asset_id);
+        const sentOffer = sentOffersMap?.get(assetKey);
+
+        if (!sentOffer) {
+          this.logger.warn(
+            `Cannot find offer output reference for "${asset.name}" in sent offers. Asset key: ${assetKey}`
+          );
           skipped.cancelOffers.push(asset.name || option.assetId);
           continue;
         }
+
+        const txHashIndex = sentOffer.outputRef; // Already in format "txHash#outputIndex"
+        this.logger.log(`Retrieved offer output reference from WayUp for "${asset.name}": ${txHashIndex}`);
 
         unlistOffers.push({ policyId: asset.policy_id, assetName: asset.asset_id, txHashIndex });
         cancelledOfferAssetIds.push(option.assetId);
@@ -1052,8 +1069,33 @@ export class GovernanceExecutionService {
           hexAssetName = option.nftSnapshot.assetName;
           nftName = option.nftSnapshot.name || nftName;
           nftImage = option.nftSnapshot.image ?? undefined;
+
+          // Verify NFT is still listed on WayUp
+          try {
+            const collectionResponse = await this.wayUpPricingService.getCollectionAssets({
+              policyId,
+              term: option.assetName,
+              limit: 1,
+            });
+
+            const exactAsset = collectionResponse.results?.[0];
+
+            if (!exactAsset?.listing) {
+              this.logger.warn(
+                `Cannot place offer for ${option.assetName} - NFT is not currently listed on WayUp marketplace`
+              );
+              skipped.offers.push(option.assetName || option.assetId);
+              continue;
+            }
+          } catch (lookupError) {
+            this.logger.warn(
+              `Cannot place offer for ${option.assetName} - WayUp lookup failed: ${lookupError.message}`
+            );
+            skipped.offers.push(option.assetName || option.assetId);
+            continue;
+          }
         } else {
-          // Fallback: query WayUp to resolve hex assetName
+          // Fallback: query WayUp to resolve hex assetName and verify listing
           try {
             const collectionResponse = await this.wayUpPricingService.getCollectionAssets({
               policyId,
@@ -1065,6 +1107,14 @@ export class GovernanceExecutionService {
 
             if (!exactAsset) {
               this.logger.warn(`Cannot place offer for ${option.assetName} - NFT not found on WayUp`);
+              skipped.offers.push(option.assetName || option.assetId);
+              continue;
+            }
+
+            if (!exactAsset.listing) {
+              this.logger.warn(
+                `Cannot place offer for ${option.assetName} - NFT is not currently listed on WayUp marketplace`
+              );
               skipped.offers.push(option.assetName || option.assetId);
               continue;
             }
@@ -1402,18 +1452,23 @@ export class GovernanceExecutionService {
               originType: AssetOriginType.OFFERED,
               status: AssetStatus.OFFERED,
             });
+
+            // Note: listing_tx_hash stores the offer transaction hash, NOT the listing transaction hash
+            // This is because the WayUp API requires the offer output reference to cancel offers
+            // The offer output reference will be retrieved from WayUp when canceling
             await this.assetRepository.update(
               { id: offeredAsset.id },
               {
                 listing_market: 'wayup',
                 listing_price: offer.priceAda,
-                // listing_tx_hash reused here to store the WayUp offer tx hash (not a marketplace
-                // listing). The CANCEL_OFFER execution reads this field to build the on-chain cancel.
+                // Store the offer transaction hash for reference (actual outputRef retrieved from WayUp when canceling)
                 listing_tx_hash: result.txHash,
                 listed_at: new Date(),
               }
             );
-            this.logger.log(`Recorded offered asset "${offer.name}" (${offer.policyId}) to vault ${proposal.vaultId}`);
+            this.logger.log(
+              `Recorded offered asset "${offer.name}" (${offer.policyId}) to vault ${proposal.vaultId} with offer tx: ${result.txHash}`
+            );
           } catch (recordError) {
             this.logger.warn(`Failed to record offered asset "${offer.name}": ${recordError.message}`);
           }
@@ -1432,9 +1487,35 @@ export class GovernanceExecutionService {
     } catch (error) {
       this.logger.error(`Error executing marketplace proposal ${proposal.id}: ${error.message}`, error.stack);
 
+      const errorMessage = error.message || '';
+
+      // Check for insufficient treasury funds - this needs immediate attention via Slack alert
+      if (errorMessage.includes('No utxo with at least') && errorMessage.includes('lovelace')) {
+        const requiredLovelaceMatch = errorMessage.match(/at least (\d+) lovelace/);
+        const requiredAda = requiredLovelaceMatch
+          ? (parseInt(requiredLovelaceMatch[1]) / 1_000_000).toFixed(2)
+          : 'unknown';
+
+        this.logger.error(
+          `Treasury wallet has insufficient funds for proposal ${proposal.id} (${proposal.title}) - needs at least ${requiredAda} ADA`
+        );
+
+        // Send Slack alert for insufficient treasury funds
+        await this.alertsService.sendAlert('treasury_insufficient_funds_marketplace', {
+          proposalId: proposal.id,
+          proposalTitle: proposal.title,
+          proposalType: proposal.proposalType,
+          vaultId: proposal.vaultId,
+          vaultName: proposal.vault?.name || 'Unknown Vault',
+          treasuryAddress: proposal.vault?.treasury_wallet?.treasury_address || 'Unknown',
+          requiredAda,
+          errorMessage,
+          timestamp: new Date().toISOString(),
+        });
+      }
+
       // Check if the error is "Listing not found" - this happens when NFT was already bought
       // In this case, we should reject the proposal instead of leaving it for retry
-      const errorMessage = error.message || '';
       if (errorMessage.includes('Listing not found') || errorMessage.includes('"code":"NOT_FOUND"')) {
         this.logger.warn(
           `Marketplace proposal ${proposal.id} rejected: Listing not found - NFT was likely already purchased`

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -898,13 +898,10 @@ export class GovernanceExecutionService {
           continue;
         }
 
-        const txHashIndex = asset.listing_tx_hash;
-        if (!txHashIndex) {
-          this.logger.warn(`Cannot cancel offer - missing listing_tx_hash for ${asset.name}`);
-          skipped.cancelOffers.push(asset.name || option.assetId);
-          continue;
-        }
-
+        // Check WayUp state FIRST — the background offer-sync cron may have already resolved
+        // this offer (accepted or cancelled) and cleared listing_tx_hash before this proposal
+        // executes. Checking listing_tx_hash before WayUp state would incorrectly skip and
+        // ultimately REJECT proposals whose offers were legitimately accepted/cancelled externally.
         if (cancelOfferMarketplaceKeys) {
           const offerState = this.wayUpPricingService.resolveOfferStatus(
             asset.policy_id,
@@ -932,6 +929,14 @@ export class GovernanceExecutionService {
           this.logger.warn(
             `Treasury wallet not configured for vault ${proposal.vaultId}; cancel-offer cannot be verified on WayUp`
           );
+          skipped.cancelOffers.push(asset.name || option.assetId);
+          continue;
+        }
+
+        // Offer is confirmed still 'active' on WayUp — require tx hash for the on-chain cancel
+        const txHashIndex = asset.listing_tx_hash;
+        if (!txHashIndex) {
+          this.logger.warn(`Cannot cancel offer - missing listing_tx_hash for ${asset.name}`);
           skipped.cancelOffers.push(asset.name || option.assetId);
           continue;
         }
@@ -1402,6 +1407,8 @@ export class GovernanceExecutionService {
               {
                 listing_market: 'wayup',
                 listing_price: offer.priceAda,
+                // listing_tx_hash reused here to store the WayUp offer tx hash (not a marketplace
+                // listing). The CANCEL_OFFER execution reads this field to build the on-chain cancel.
                 listing_tx_hash: result.txHash,
                 listed_at: new Date(),
               }

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -26,7 +26,7 @@ import { TreasuryWalletService } from '@/modules/vaults/treasure/treasure-wallet
 import { TreasuryExtractionService } from '@/modules/vaults/treasure/treasury-extraction.service';
 import { WayUpPricingService } from '@/modules/wayup/wayup-pricing.service';
 import { WayUpService } from '@/modules/wayup/wayup.service';
-import { AssetStatus } from '@/types/asset.types';
+import { AssetOriginType, AssetStatus } from '@/types/asset.types';
 import { ClaimType } from '@/types/claim.types';
 import { ProposalStatus, ProposalType } from '@/types/proposal.types';
 import { RewardActivityType } from '@/types/rewards.types';
@@ -868,7 +868,33 @@ export class GovernanceExecutionService {
         unlistedAssetIds.push(option.assetId);
       }
 
-      // Process CANCEL_OFFER operations
+      // Process CANCEL_OFFER operations (verify offer still exists on WayUp before on-chain cancel)
+      const treasuryAddress = proposal.vault.treasury_wallet?.treasury_address;
+      let cancelOfferMarketplaceKeys: { active: Set<string>; treasury: Set<string> } | null = null;
+
+      if (operations.cancelOffers.length > 0 && treasuryAddress) {
+        try {
+          const [sentOffers, treasuryAssets] = await Promise.all([
+            this.wayUpPricingService.getWalletSentOffers(treasuryAddress),
+            this.wayUpPricingService.getWalletAssets(treasuryAddress),
+          ]);
+          cancelOfferMarketplaceKeys = {
+            active: new Set(sentOffers.map(o => this.wayUpPricingService.offerAssetKey(o.policyId, o.assetName))),
+            treasury: new Set(treasuryAssets.map(a => this.wayUpPricingService.offerAssetKey(a.policyId, a.assetName))),
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          this.logger.error(
+            `Failed to fetch WayUp offer state for cancel-offer execution in proposal ${proposal.id}: ${errorMessage}`,
+            error instanceof Error ? error.stack : undefined
+          );
+          throw new Error(`Unable to verify offer status on WayUp before cancel-offer execution: ${errorMessage}`);
+        }
+      }
+
+      const autoResolvedAcceptedOfferIds: string[] = [];
+      const autoResolvedCancelledOfferIds: string[] = [];
+
       for (const option of operations.cancelOffers) {
         const asset = assetMap.get(option.assetId);
         if (!asset) {
@@ -884,8 +910,55 @@ export class GovernanceExecutionService {
           continue;
         }
 
+        if (cancelOfferMarketplaceKeys) {
+          const offerState = this.wayUpPricingService.resolveOfferStatus(
+            asset.policy_id,
+            asset.asset_id,
+            cancelOfferMarketplaceKeys.active,
+            cancelOfferMarketplaceKeys.treasury
+          );
+
+          if (offerState === 'accepted') {
+            autoResolvedAcceptedOfferIds.push(option.assetId);
+            this.logger.log(
+              `Cancel-offer skipped for "${asset.name}": offer already accepted on WayUp, marking asset as bought/extracted`
+            );
+            continue;
+          }
+
+          if (offerState === 'cancelled') {
+            autoResolvedCancelledOfferIds.push(option.assetId);
+            this.logger.log(
+              `Cancel-offer skipped for "${asset.name}": offer no longer active on WayUp, marking as cancel_offer`
+            );
+            continue;
+          }
+        } else if (operations.cancelOffers.length > 0) {
+          this.logger.warn(
+            `Treasury wallet not configured for vault ${proposal.vaultId}; cancel-offer cannot be verified on WayUp`
+          );
+          skipped.cancelOffers.push(asset.name || option.assetId);
+          continue;
+        }
+
         unlistOffers.push({ policyId: asset.policy_id, txHashIndex });
         cancelledOfferAssetIds.push(option.assetId);
+      }
+
+      if (autoResolvedAcceptedOfferIds.length > 0) {
+        try {
+          await this.assetsService.markOffersAsAccepted(autoResolvedAcceptedOfferIds);
+        } catch (statusError) {
+          this.logger.warn(`Failed to mark accepted offers after WayUp check: ${statusError.message}`);
+        }
+      }
+
+      if (autoResolvedCancelledOfferIds.length > 0) {
+        try {
+          await this.assetsService.markOffersAsCancelled(autoResolvedCancelledOfferIds);
+        } catch (statusError) {
+          this.logger.warn(`Failed to mark cancelled offers after WayUp check: ${statusError.message}`);
+        }
       }
 
       // Process UPDATE_LISTING operations
@@ -1097,6 +1170,19 @@ export class GovernanceExecutionService {
         purchases.length > 0 ||
         offers.length > 0;
 
+      const allCancelOffersResolvedOnWayUp =
+        operations.cancelOffers.length > 0 &&
+        unlistOffers.length === 0 &&
+        skipped.cancelOffers.length === 0 &&
+        autoResolvedAcceptedOfferIds.length + autoResolvedCancelledOfferIds.length === operations.cancelOffers.length;
+
+      if (!hasOperations && allCancelOffersResolvedOnWayUp) {
+        this.logger.log(
+          `Proposal ${proposal.id}: all ${operations.cancelOffers.length} cancel-offer(s) resolved from WayUp state (no on-chain tx needed)`
+        );
+        return true;
+      }
+
       if (!hasOperations) {
         const totalSkipped =
           skipped.sells.length +
@@ -1254,17 +1340,8 @@ export class GovernanceExecutionService {
       // Update canceled offers
       if (unlistOffers.length > 0) {
         try {
-          await this.assetRepository.update(
-            { id: In(cancelledOfferAssetIds) },
-            {
-              status: AssetStatus.EXTRACTED,
-              listing_tx_hash: null,
-              listing_market: null,
-              listing_price: null,
-              listed_at: null,
-            }
-          );
-          this.logger.log(`Marked ${cancelledOfferAssetIds.length} asset(s) as EXTRACTED (offer cancelled)`);
+          await this.assetsService.markOffersAsCancelled(cancelledOfferAssetIds);
+          this.logger.log(`Marked ${cancelledOfferAssetIds.length} asset(s) as CANCEL_OFFER`);
         } catch (statusError) {
           this.logger.warn(`Failed to update cancelled offer asset statuses: ${statusError.message}`);
         }
@@ -1286,7 +1363,7 @@ export class GovernanceExecutionService {
         }
       }
 
-      // Record bought assets to the vault with origin_type BOUGHT, status EXTRACTED, added_by null
+      // Record bought assets: origin BOUGHT, status EXTRACTED
       if (purchases.length > 0) {
         for (const purchase of purchases) {
           try {
@@ -1298,6 +1375,7 @@ export class GovernanceExecutionService {
               image: purchase.image,
               floorPrice: purchase.priceAda,
               metadata: purchase.metadata,
+              originType: AssetOriginType.BOUGHT,
               status: AssetStatus.EXTRACTED,
             });
             this.logger.log(
@@ -1309,7 +1387,7 @@ export class GovernanceExecutionService {
         }
       }
 
-      // Record offered assets to the vault with origin_type BOUGHT, status OFFERED, added_by null
+      // Record offered assets: origin OFFERED, status OFFERED
       if (offers.length > 0) {
         for (const offer of offers) {
           try {
@@ -1321,6 +1399,7 @@ export class GovernanceExecutionService {
               image: offer.image,
               floorPrice: offer.priceAda,
               metadata: offer.metadata,
+              originType: AssetOriginType.OFFERED,
               status: AssetStatus.OFFERED,
             });
             await this.assetRepository.update(

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -717,7 +717,7 @@ export class GovernanceExecutionService {
     const market = proposal.metadata.marketplaceActions[0]?.market;
 
     // Handle DexHunter FT swaps
-    if (market === 'DexHunter') {
+    if (market?.toLowerCase() === 'dexhunter') {
       return this.executeDexHunterSwapProposal(proposal);
     }
 

--- a/src/modules/vaults/phase-management/governance/governance-execution.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance-execution.service.ts
@@ -2371,7 +2371,7 @@ export class GovernanceExecutionService {
       PRICE_EXCEEDED:
         'One or more NFTs now have a listing price higher than the maximum price specified in the proposal.',
       OFFER_OPERATION_SKIPPED:
-        'One or more offer operations could not be executed (NFT not found on WayUp or invalid offer price).',
+        'One or more offer or cancel-offer operations could not be executed (NFT not found on WayUp, offer not active, or invalid offer price).',
       CONTRACT_ERROR: 'Smart contract validation error.',
       EXECUTION_ERROR: 'Unexpected error. Review details or contact support.',
     };

--- a/src/modules/vaults/phase-management/governance/governance.controller.ts
+++ b/src/modules/vaults/phase-management/governance/governance.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Delete, Get, Param, ParseUUIDPipe, Post, Query, Req, 
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { DistributionService } from './distribution.service';
+import { AssetMetadataRes } from './dto/asset-metadata.res';
 import { CreateProposalReq } from './dto/create-proposal.req';
 import { CreateProposalRes } from './dto/create-proposal.res';
 import { GetDistributionInfoRes } from './dto/distribution.dto';
@@ -228,6 +229,23 @@ export class GovernanceController {
   @ApiResponse({ status: 200, description: 'List of assets to burn' })
   async getAssetsToBurn(@Param('vaultId', ParseUUIDPipe) vaultId: string): Promise<AssetBuySellDto[]> {
     return this.governanceService.getAssetsToBurn(vaultId);
+  }
+
+  @Get('assets/metadata/:unit')
+  @ApiOperation({
+    summary: 'Get asset metadata by unit from Blockfrost',
+    description:
+      'Fetches on-chain asset metadata including display name. Unit must be at least 56 hex characters (policy ID + optional asset name).',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Asset metadata fetched successfully',
+    type: AssetMetadataRes,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid unit format' })
+  @ApiResponse({ status: 404, description: 'Asset not found on-chain' })
+  async getAssetMetadata(@Param('unit') unit: string): Promise<AssetMetadataRes> {
+    return this.governanceService.getAssetMetadataByUnit(unit);
   }
 
   @Get('vaults/:vaultId/swappable-assets')

--- a/src/modules/vaults/phase-management/governance/governance.controller.ts
+++ b/src/modules/vaults/phase-management/governance/governance.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, ParseUUIDPipe, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseUUIDPipe, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { DistributionService } from './distribution.service';
@@ -7,6 +7,7 @@ import { CreateProposalRes } from './dto/create-proposal.res';
 import { GetDistributionInfoRes } from './dto/distribution.dto';
 import { GetAssetsToListRes } from './dto/get-assets-to-list.res';
 import { GetAssetsToStakeRes } from './dto/get-assets-to-stake.res';
+import { GetOffersToCancelDto, PaginatedOffersToCancelResponseDto } from './dto/get-offers-to-cancel.dto';
 import { GetProposalDetailRes } from './dto/get-proposal-detail.res';
 import { GetProposalsRes, GetProposalsResItem } from './dto/get-proposal.dto';
 import { GetVotingPowerRes } from './dto/get-voting-power.res';
@@ -23,6 +24,7 @@ import { GovernanceService } from './governance.service';
 import { AuthGuard } from '@/modules/auth/auth.guard';
 import { AuthRequest } from '@/modules/auth/dto/auth-user.interface';
 import { OptionalAuthGuard } from '@/modules/auth/optional-auth.guard';
+import { PaginatedResponseDto } from '@/modules/vaults/dto/paginated-response.dto';
 import {
   AssetBuySellDto,
   GetTerminationAssetsDto,
@@ -142,16 +144,23 @@ export class GovernanceController {
     return await this.governanceService.getAssetsToList(vaultId);
   }
 
-  @Get('vaults/:vaultId/assets/cancel-offer')
+  @Get('vaults/:vaultId/offers-to-cancel')
   @UseGuards(AuthGuard)
-  @ApiOperation({ summary: 'Get assets available for cancel-offer proposals' })
+  @ApiOperation({
+    summary: 'Get offers available for CANCEL_OFFER proposals',
+    description:
+      'Returns paginated active vault offers (OFFERED status) that can be cancelled via governance. Supports search by name, policy ID, or asset ID.',
+  })
   @ApiResponse({
     status: 200,
-    description: 'List of offered assets that can be cancelled',
-    type: [AssetBuySellDto],
+    description: 'Paginated list of offers to cancel',
+    type: PaginatedOffersToCancelResponseDto,
   })
-  async getAssetsToCancelOffer(@Param('vaultId', ParseUUIDPipe) vaultId: string): Promise<AssetBuySellDto[]> {
-    return this.governanceService.getAssetsToCancelOffer(vaultId);
+  async getOffersToCancel(
+    @Param('vaultId', ParseUUIDPipe) vaultId: string,
+    @Query() query: GetOffersToCancelDto
+  ): Promise<PaginatedResponseDto<AssetBuySellDto>> {
+    return this.governanceService.getOffersToCancel(vaultId, query.page, query.limit, query.search);
   }
 
   @Get('vaults/:vaultId/assets/unlist')

--- a/src/modules/vaults/phase-management/governance/governance.controller.ts
+++ b/src/modules/vaults/phase-management/governance/governance.controller.ts
@@ -133,12 +133,12 @@ export class GovernanceController {
     return { votingPower };
   }
 
-  @Get('vaults/:vaultId/assets/buy-sell')
+  @Get('vaults/:vaultId/assets/sell')
   @UseGuards(AuthGuard)
-  @ApiOperation({ summary: 'Get assets available for buying/selling proposals' })
+  @ApiOperation({ summary: 'Get assets available for selling proposals' })
   @ApiResponse({
     status: 200,
-    description: 'List of assets available for trading',
+    description: 'List of assets available for selling',
     type: GetAssetsToListRes,
   })
   async getAssetsToList(@Param('vaultId', ParseUUIDPipe) vaultId: string): Promise<GetAssetsToListRes> {

--- a/src/modules/vaults/phase-management/governance/governance.controller.ts
+++ b/src/modules/vaults/phase-management/governance/governance.controller.ts
@@ -142,6 +142,18 @@ export class GovernanceController {
     return await this.governanceService.getAssetsToList(vaultId);
   }
 
+  @Get('vaults/:vaultId/assets/cancel-offer')
+  @UseGuards(AuthGuard)
+  @ApiOperation({ summary: 'Get assets available for cancel-offer proposals' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of offered assets that can be cancelled',
+    type: [AssetBuySellDto],
+  })
+  async getAssetsToCancelOffer(@Param('vaultId', ParseUUIDPipe) vaultId: string): Promise<AssetBuySellDto[]> {
+    return this.governanceService.getAssetsToCancelOffer(vaultId);
+  }
+
   @Get('vaults/:vaultId/assets/unlist')
   @UseGuards(AuthGuard)
   @ApiOperation({ summary: 'Get assets available for unlisting proposals' })

--- a/src/modules/vaults/phase-management/governance/governance.controller.ts
+++ b/src/modules/vaults/phase-management/governance/governance.controller.ts
@@ -232,6 +232,7 @@ export class GovernanceController {
   }
 
   @Get('assets/metadata/:unit')
+  @UseGuards(AuthGuard)
   @ApiOperation({
     summary: 'Get asset metadata by unit from Blockfrost',
     description:

--- a/src/modules/vaults/phase-management/governance/governance.controller.ts
+++ b/src/modules/vaults/phase-management/governance/governance.controller.ts
@@ -19,7 +19,7 @@ import {
 import { VoteReq } from './dto/vote.req';
 import { VoteRes } from './dto/vote.res';
 import { GovernanceFeeService } from './governance-fee.service';
-import { GovernanceService } from './governance.service';
+import GovernanceService from './governance.service';
 
 import { AuthGuard } from '@/modules/auth/auth.guard';
 import { AuthRequest } from '@/modules/auth/dto/auth-user.interface';

--- a/src/modules/vaults/phase-management/governance/governance.module.ts
+++ b/src/modules/vaults/phase-management/governance/governance.module.ts
@@ -13,7 +13,7 @@ import { GovernanceExecutionService } from './governance-execution.service';
 import { GovernanceFeeService } from './governance-fee.service';
 import { GovernanceRefundService } from './governance-refund.service';
 import { GovernanceController } from './governance.controller';
-import { GovernanceService } from './governance.service';
+import GovernanceService from './governance.service';
 import { ProposalHealthService } from './proposal-health.service';
 import { ProposalSchedulerService } from './proposal-scheduler.service';
 import { TerminationController } from './termination.controller';

--- a/src/modules/vaults/phase-management/governance/governance.module.ts
+++ b/src/modules/vaults/phase-management/governance/governance.module.ts
@@ -16,7 +16,7 @@ import { GovernanceController } from './governance.controller';
 import GovernanceService from './governance.service';
 import { ProposalHealthService } from './proposal-health.service';
 import { ProposalSchedulerService } from './proposal-scheduler.service';
-import { SnapshotService } from './snapshot.service';
+import { SnapshotModule } from './snapshot.module';
 import { TerminationController } from './termination.controller';
 import { TerminationService } from './termination.service';
 import { VoteCountingService } from './vote-counting.service';
@@ -59,6 +59,7 @@ import { WayUpModule } from '@/modules/wayup/wayup.module';
       TokenVerification,
     ]),
     RedisModule,
+    SnapshotModule,
     AssetsModule,
     WayUpModule,
     TreasureWalletModule,
@@ -83,7 +84,6 @@ import { WayUpModule } from '@/modules/wayup/wayup.module';
     VoteCountingService,
     TerminationService,
     DistributionService,
-    SnapshotService,
     {
       provide: ProposalHealthService,
       useFactory: (
@@ -104,7 +104,6 @@ import { WayUpModule } from '@/modules/wayup/wayup.module';
     TerminationService,
     DistributionService,
     ExpansionService,
-    SnapshotService,
   ],
 })
 export class GovernanceModule {}

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -510,6 +510,10 @@ export class GovernanceService {
           .filter(action => action.exec === ExecType.OFFER)
           .map(action => action.assetId);
 
+        const requestedCancelOfferAssetIds = requestedActions
+          .filter(action => action.exec === ExecType.CANCEL_OFFER)
+          .map(action => action.assetId);
+
         const activeMarketProposals = await this.proposalRepository.find({
           where: {
             vaultId,
@@ -524,7 +528,7 @@ export class GovernanceService {
           // Check DB assets (SELL / UNLIST / UPDATE_LISTING)
           if (requestedAssetIds.length > 0) {
             const existingDbAssetIds = existingActions
-              .filter((a: any) => a.exec !== ExecType.BUY)
+              .filter((a: any) => a.exec !== ExecType.BUY && a.exec !== ExecType.OFFER)
               .map((a: any) => a.assetId);
 
             const overlapping = requestedAssetIds.filter(id => existingDbAssetIds.includes(id));
@@ -558,6 +562,28 @@ export class GovernanceService {
               throw new BadRequestException(
                 `Cannot create proposal. Some NFTs already have an active buy or offer proposal "${existingProposal.title}". ` +
                   `Please wait for that proposal to complete before creating a new one for these NFTs.`
+              );
+            }
+          }
+
+          // Check CANCEL_OFFER assets — one active cancel-offer proposal per offered asset
+          if (requestedCancelOfferAssetIds.length > 0) {
+            const existingCancelOfferAssetIds = existingActions
+              .filter((a: any) => a.exec === ExecType.CANCEL_OFFER)
+              .map((a: any) => a.assetId);
+
+            const overlapping = requestedCancelOfferAssetIds.filter(id => existingCancelOfferAssetIds.includes(id));
+
+            if (overlapping.length > 0) {
+              const records = await this.assetRepository.find({
+                where: { id: In(overlapping) },
+                select: ['id', 'name'],
+              });
+              const assetNames = records.map(a => a.name || a.id).join(', ');
+
+              throw new BadRequestException(
+                `Cannot create cancel-offer proposal. The following assets already have an active cancel-offer proposal "${existingProposal.title}": ${assetNames}. ` +
+                  `Please wait for that proposal to complete before creating a new one for these assets.`
               );
             }
           }
@@ -987,11 +1013,73 @@ export class GovernanceService {
               return;
             }
 
-            const asset: Pick<Asset, 'id' | 'status' | 'type' | 'policy_id' | 'asset_id' | 'quantity' | 'name'> =
-              await this.assetRepository.findOne({
-                where: { id: action.assetId },
-                select: ['id', 'status', 'type', 'policy_id', 'asset_id', 'quantity', 'name'],
+            // CANCEL_OFFER actions cancel an existing vault offer (DB asset with OFFERED status)
+            if (action.exec === ExecType.CANCEL_OFFER) {
+              if (market !== 'WayUp') {
+                throw new BadRequestException('CANCEL_OFFER is only supported on WayUp marketplace');
+              }
+
+              const offeredAsset = await this.assetRepository.findOne({
+                where: { id: action.assetId, vault: { id: vaultId }, deleted: false },
+                select: [
+                  'id',
+                  'status',
+                  'type',
+                  'policy_id',
+                  'asset_id',
+                  'quantity',
+                  'name',
+                  'image',
+                  'metadata',
+                  'listing_tx_hash',
+                  'listing_price',
+                  'floor_price',
+                ],
               });
+
+              if (!offeredAsset) {
+                throw new BadRequestException(`Asset with ID ${action.assetId} not found`);
+              }
+
+              if (offeredAsset.type !== AssetType.NFT) {
+                throw new BadRequestException(
+                  `CANCEL_OFFER only supports NFT assets. Asset ${action.assetId} is not an NFT.`
+                );
+              }
+
+              if (offeredAsset.status !== AssetStatus.OFFERED) {
+                throw new BadRequestException(
+                  `Asset "${offeredAsset.name || action.assetId}" is not in OFFERED status. Only active offers can be cancelled.`
+                );
+              }
+
+              if (!offeredAsset.listing_tx_hash) {
+                throw new BadRequestException(
+                  `Asset "${offeredAsset.name || action.assetId}" is missing offer transaction reference. Cannot create cancel-offer proposal.`
+                );
+              }
+
+              const offerPriceAda = Number(offeredAsset.listing_price ?? offeredAsset.floor_price ?? 0);
+
+              action.nftSnapshot = {
+                name: offeredAsset.name || offeredAsset.metadata?.name || 'Unknown NFT',
+                image: offeredAsset.image ?? null,
+                listingPriceAda: offerPriceAda,
+                policyId: offeredAsset.policy_id,
+                assetName: offeredAsset.asset_id,
+                collectionName: null,
+              };
+
+              return;
+            }
+
+            const asset: Pick<
+              Asset,
+              'id' | 'status' | 'type' | 'policy_id' | 'asset_id' | 'quantity' | 'name' | 'listing_tx_hash'
+            > = await this.assetRepository.findOne({
+              where: { id: action.assetId },
+              select: ['id', 'status', 'type', 'policy_id', 'asset_id', 'quantity', 'name', 'listing_tx_hash'],
+            });
 
             if (!asset) {
               throw new BadRequestException(`Asset with ID ${action.assetId} not found`);
@@ -1724,9 +1812,10 @@ export class GovernanceService {
     const marketplaceActions = (proposal.metadata?.marketplaceActions || []).map(action => {
       const isBuy = action.exec === 'BUY';
       const isOffer = action.exec === 'OFFER';
+      const isCancelOffer = action.exec === 'CANCEL_OFFER';
       const isSwapAction = action.slippage !== undefined || action.market === 'DexHunter';
 
-      if (isBuy || isOffer) {
+      if (isBuy || isOffer || isCancelOffer) {
         let wayupUrl: string | undefined;
         if (!isSwapAction && action.nftSnapshot) {
           wayupUrl = `https://www.wayup.io/collection/${action.nftSnapshot.policyId}/asset/${action.nftSnapshot.assetName}?tab=activity`;
@@ -2702,6 +2791,44 @@ export class GovernanceService {
     } catch (error) {
       this.logger.error(`Error getting assets for buy-sell proposals for vault ${vaultId}: ${error.message}`);
       throw new InternalServerErrorException('Error getting assets for buying/selling');
+    }
+  }
+
+  async getAssetsToCancelOffer(vaultId: string): Promise<AssetBuySellDto[]> {
+    try {
+      const assets = await this.assetRepository.find({
+        where: {
+          vault: { id: vaultId },
+          type: AssetType.NFT,
+          status: AssetStatus.OFFERED,
+          deleted: false,
+        },
+        select: [
+          'id',
+          'name',
+          'policy_id',
+          'asset_id',
+          'quantity',
+          'dex_price',
+          'floor_price',
+          'image',
+          'metadata',
+          'type',
+          'listing_market',
+          'listing_price',
+          'listing_tx_hash',
+          'listed_at',
+        ],
+      });
+
+      const cancellableOffers = assets.filter(asset => !!asset.listing_tx_hash);
+
+      return plainToInstance(AssetBuySellDto, cancellableOffers, {
+        excludeExtraneousValues: true,
+      });
+    } catch (error) {
+      this.logger.error(`Error getting assets to cancel offer for vault ${vaultId}: ${error.message}`);
+      throw new InternalServerErrorException('Error getting assets for cancel-offer proposals');
     }
   }
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -954,6 +954,24 @@ export class GovernanceService {
                   );
                 }
 
+                const existingOfferedAsset = await this.assetRepository.findOne({
+                  where: {
+                    vault: { id: vaultId },
+                    policy_id: exactAsset.policyId,
+                    asset_id: exactAsset.assetName,
+                    status: AssetStatus.OFFERED,
+                    deleted: false,
+                  },
+                  select: ['id', 'name'],
+                });
+
+                if (existingOfferedAsset) {
+                  throw new BadRequestException(
+                    `An active offer already exists in this vault for NFT ${displayName}. ` +
+                      `Wait until the offer is accepted, cancelled, or removed before creating a new offer proposal.`
+                  );
+                }
+
                 const offerPriceAda = parseFloat(action.price);
                 const currentListingPriceAda = exactAsset.listing ? exactAsset.listing.price / 1_000_000 : null;
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -14,7 +14,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { plainToInstance } from 'class-transformer';
 import NodeCache from 'node-cache';
-import { In, IsNull, Not, Repository } from 'typeorm';
+import { Brackets, In, IsNull, Not, Repository } from 'typeorm';
 
 import { TransactionsService } from '../../processing-tx/offchain-tx/transactions.service';
 import { BlockchainService } from '../../processing-tx/onchain/blockchain.service';
@@ -44,6 +44,7 @@ import { DexHunterService } from '@/modules/dexhunter/dexhunter.service';
 import { SystemSettingsService } from '@/modules/globals/system-settings/system-settings.service';
 import { RewardEventProducer } from '@/modules/rewards/services/reward-event-producer.service';
 import { TaptoolsService } from '@/modules/taptools/taptools.service';
+import { PaginatedResponseDto } from '@/modules/vaults/dto/paginated-response.dto';
 import { GetAssetsToListRes } from '@/modules/vaults/phase-management/governance/dto/get-assets-to-list.res';
 import { TreasuryWalletService } from '@/modules/vaults/treasure/treasure-wallet.service';
 import { WayUpPricingService } from '@/modules/wayup/wayup-pricing.service';
@@ -2794,41 +2795,72 @@ export class GovernanceService {
     }
   }
 
-  async getAssetsToCancelOffer(vaultId: string): Promise<AssetBuySellDto[]> {
+  async getOffersToCancel(
+    vaultId: string,
+    page: number = 1,
+    limit: number = 10,
+    search?: string
+  ): Promise<PaginatedResponseDto<AssetBuySellDto>> {
     try {
-      const assets = await this.assetRepository.find({
-        where: {
-          vault: { id: vaultId },
-          type: AssetType.NFT,
-          status: AssetStatus.OFFERED,
-          deleted: false,
-        },
-        select: [
-          'id',
-          'name',
-          'policy_id',
-          'asset_id',
-          'quantity',
-          'dex_price',
-          'floor_price',
-          'image',
-          'metadata',
-          'type',
-          'listing_market',
-          'listing_price',
-          'listing_tx_hash',
-          'listed_at',
-        ],
-      });
+      const safePage = page > 0 ? page : 1;
+      const safeLimit = limit > 0 ? limit : 10;
+      const skip = (safePage - 1) * safeLimit;
 
-      const cancellableOffers = assets.filter(asset => !!asset.listing_tx_hash);
+      const query = this.assetRepository
+        .createQueryBuilder('asset')
+        .where('asset.vault_id = :vaultId', { vaultId })
+        .andWhere('asset.type = :type', { type: AssetType.NFT })
+        .andWhere('asset.status = :status', { status: AssetStatus.OFFERED })
+        .andWhere('asset.deleted = :deleted', { deleted: false })
+        .andWhere('asset.listing_tx_hash IS NOT NULL');
 
-      return plainToInstance(AssetBuySellDto, cancellableOffers, {
+      const trimmedSearch = search?.trim();
+      if (trimmedSearch) {
+        query.andWhere(
+          new Brackets(qb => {
+            qb.where('asset.name ILIKE :search', { search: `%${trimmedSearch}%` })
+              .orWhere('asset.policy_id ILIKE :search', { search: `%${trimmedSearch}%` })
+              .orWhere('asset.asset_id ILIKE :search', { search: `%${trimmedSearch}%` });
+          })
+        );
+      }
+
+      const [assets, total] = await query
+        .select([
+          'asset.id',
+          'asset.name',
+          'asset.policy_id',
+          'asset.asset_id',
+          'asset.quantity',
+          'asset.dex_price',
+          'asset.floor_price',
+          'asset.image',
+          'asset.metadata',
+          'asset.type',
+          'asset.listing_market',
+          'asset.listing_price',
+          'asset.listing_tx_hash',
+          'asset.listed_at',
+        ])
+        .orderBy('asset.listed_at', 'DESC')
+        .skip(skip)
+        .take(safeLimit)
+        .getManyAndCount();
+
+      const items = plainToInstance(AssetBuySellDto, assets, {
         excludeExtraneousValues: true,
       });
+
+      return {
+        items,
+        total,
+        page: safePage,
+        limit: safeLimit,
+        totalPages: Math.ceil(total / safeLimit) || 0,
+      };
     } catch (error) {
-      this.logger.error(`Error getting assets to cancel offer for vault ${vaultId}: ${error.message}`);
-      throw new InternalServerErrorException('Error getting assets for cancel-offer proposals');
+      this.logger.error(`Error getting offers to cancel for vault ${vaultId}: ${error.message}`);
+      throw new InternalServerErrorException('Error getting offers to cancel');
     }
   }
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -891,7 +891,7 @@ export class GovernanceService {
         const actions = createProposalReq.marketplaceActions || [];
 
         // Validate that all actions use the same market (no mixing DexHunter and WayUp)
-        const markets = new Set(actions.map(a => a.market));
+        const markets = new Set(actions.map(a => a.market?.toLowerCase()));
         if (markets.size > 1) {
           throw new BadRequestException(
             'Cannot mix different markets in same proposal. Use either DexHunter or WayUp, not both.'
@@ -901,7 +901,7 @@ export class GovernanceService {
         const market = actions[0]?.market;
 
         // Pre-check (mainnet only): ensure treasury has enough ADA for WayUp BUY and OFFER operations
-        if (this.isMainnet && market === 'WayUp') {
+        if (this.isMainnet && market?.toLowerCase() === 'wayup') {
           const buyActions = actions.filter(a => a.exec === ExecType.BUY);
           const offerActions = actions.filter(a => a.exec === ExecType.OFFER);
 
@@ -951,7 +951,7 @@ export class GovernanceService {
           Array<Pick<Asset, 'id' | 'status' | 'type' | 'policy_id' | 'asset_id' | 'quantity' | 'name'>>
         >();
 
-        if (market === 'DexHunter') {
+        if (market?.toLowerCase() === 'dexhunter') {
           // Fetch all swappable FT assets (LOCKED in vault + EXTRACTED in treasury)
           const allFTs = await this.assetRepository.find({
             where: {
@@ -977,7 +977,7 @@ export class GovernanceService {
           actions.map(async action => {
             // BUY actions target external NFTs (not in our DB) — skip DB lookup, validate via WayUp API below
             if (action.exec === ExecType.BUY) {
-              if (market === 'WayUp') {
+              if (market?.toLowerCase() === 'wayup') {
                 const policyId = action.assetId.length >= 56 ? action.assetId.slice(0, 56) : action.assetId;
 
                 const isWhitelisted = vault.assets_whitelist?.some(
@@ -1032,7 +1032,7 @@ export class GovernanceService {
 
             // OFFER actions target external NFTs — validate policy whitelist and NFT existence via WayUp API
             if (action.exec === ExecType.OFFER) {
-              if (market === 'WayUp') {
+              if (market?.toLowerCase() === 'wayup') {
                 const policyId = action.assetId.length >= 56 ? action.assetId.slice(0, 56) : action.assetId;
 
                 const isWhitelisted = vault.assets_whitelist?.some(
@@ -1111,7 +1111,7 @@ export class GovernanceService {
 
             // CANCEL_OFFER actions cancel an existing vault offer (DB asset with OFFERED status)
             if (action.exec === ExecType.CANCEL_OFFER) {
-              if (market !== 'WayUp') {
+              if (market?.toLowerCase() !== 'wayup') {
                 throw new BadRequestException('CANCEL_OFFER is only supported on WayUp marketplace');
               }
 
@@ -1225,7 +1225,7 @@ export class GovernanceService {
             }
 
             // DexHunter swap validation (FT tokens only)
-            if (market === 'DexHunter') {
+            if (market?.toLowerCase() === 'dexhunter') {
               // Validate it's a fungible token
               if (asset.type !== AssetType.FT) {
                 throw new BadRequestException(
@@ -1321,7 +1321,7 @@ export class GovernanceService {
               }
             }
             // WayUp marketplace validation (NFTs)
-            else if (market === 'WayUp') {
+            else if (market?.toLowerCase() === 'wayup') {
               // Validate price is provided for SELL (LIST) actions
               if (action.exec === ExecType.SELL) {
                 // For List sellType, price is REQUIRED
@@ -1383,7 +1383,7 @@ export class GovernanceService {
         );
 
         // For DexHunter swaps, resolve specific asset IDs needed for each action
-        if (market === 'DexHunter') {
+        if (market?.toLowerCase() === 'dexhunter') {
           for (const action of actions) {
             const asset = await this.assetRepository.findOne({
               where: { id: action.assetId },
@@ -2238,7 +2238,7 @@ export class GovernanceService {
       const isBuy = action.exec === ExecType.BUY;
       const isOffer = action.exec === ExecType.OFFER;
       const isCancelOffer = action.exec === ExecType.CANCEL_OFFER;
-      const isSwapAction = action.slippage !== undefined || action.market === 'DexHunter';
+      const isSwapAction = action.slippage !== undefined || action.market?.toLowerCase() === 'dexhunter';
 
       if (isBuy || isOffer || isCancelOffer) {
         let wayupUrl: string | undefined;

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -3178,7 +3178,7 @@ export class GovernanceService {
             vault: { id: vaultId },
             type: In([AssetType.NFT]),
             status: In([AssetStatus.LOCKED, AssetStatus.EXTRACTED]),
-            origin_type: AssetOriginType.CONTRIBUTED,
+            origin_type: In([AssetOriginType.CONTRIBUTED, AssetOriginType.BOUGHT]),
           },
         ],
         select: [
@@ -3206,8 +3206,8 @@ export class GovernanceService {
         treasuryWalletBalance,
       };
     } catch (error) {
-      this.logger.error(`Error getting assets for buy-sell proposals for vault ${vaultId}: ${error.message}`);
-      throw new InternalServerErrorException('Error getting assets for buying/selling');
+      this.logger.error(`Error getting assets for sell proposals for vault ${vaultId}: ${error.message}`);
+      throw new InternalServerErrorException('Error getting assets for selling');
     }
   }
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -91,6 +91,7 @@ export class GovernanceService {
   private readonly isMainnet: boolean;
   private readonly votingPowerCache: NodeCache;
   private readonly proposalCreationCache: NodeCache;
+  private readonly assetMetadataCache: NodeCache;
   private readonly poolAddress: string;
   private readonly adminAddress: string;
   private readonly MIN_LP_ADA_FOR_MARKET_PRICING = 5000;
@@ -148,7 +149,7 @@ export class GovernanceService {
     this.adminAddress = this.configService.get<string>('ADMIN_ADDRESS');
 
     this.blockfrost = new BlockFrostAPI({
-      projectId: this.configService.get<string>('BLOCKFROST_API_KEY'),
+      projectId: this.configService.get<string>('BLOCKFROST_API_KEY_MAINNET'),
     });
     this.votingPowerCache = new NodeCache({
       stdTTL: this.CACHE_TTL.VOTING_POWER,
@@ -159,6 +160,12 @@ export class GovernanceService {
     this.proposalCreationCache = new NodeCache({
       stdTTL: this.CACHE_TTL.CAN_CREATE_PROPOSAL,
       checkperiod: 300,
+      useClones: false,
+    });
+
+    this.assetMetadataCache = new NodeCache({
+      stdTTL: 3600, // 1 hour
+      checkperiod: 600,
       useClones: false,
     });
   }
@@ -3344,6 +3351,64 @@ export class GovernanceService {
     } catch (error) {
       this.logger.error(`Error getting assets to update listing for vault ${vaultId}: ${error.message}`);
       throw new InternalServerErrorException('Error getting assets for updating listings');
+    }
+  }
+
+  /**
+   * Get asset metadata by unit from Blockfrost
+   * Validates unit format (56 hex chars for policy + optional asset name)
+   * Returns display name only
+   */
+  async getAssetMetadataByUnit(unit: string): Promise<{ displayName: string }> {
+    // Validate unit format: at least 56 hex characters (policy ID)
+    const hexPattern = /^[a-fA-F0-9]{56,}$/;
+    if (!unit || !hexPattern.test(unit)) {
+      throw new BadRequestException(
+        'Invalid asset unit format. Must be at least 56 hexadecimal characters (policy ID + optional asset name)'
+      );
+    }
+
+    // Check cache first (1 hour TTL)
+    const cacheKey = `asset_metadata:${unit}`;
+    const cached = this.assetMetadataCache.get<{ displayName: string }>(cacheKey);
+
+    if (cached) {
+      this.logger.debug(`Cache hit for asset metadata: ${unit}`);
+      return cached;
+    }
+
+    try {
+      // Fetch from Blockfrost
+      const assetInfo = await this.blockfrost.assetsById(unit);
+
+      // Extract display name with fallback priority: onchain_metadata.name → asset_name → "Unknown Asset"
+      let displayName = 'Unknown Asset';
+      if (assetInfo.onchain_metadata?.name) {
+        displayName = assetInfo?.onchain_metadata?.name as any;
+      } else if (assetInfo.asset_name) {
+        // Convert hex asset name to UTF-8 if possible
+        try {
+          displayName = Buffer.from(assetInfo.asset_name, 'hex').toString('utf8');
+        } catch {
+          displayName = assetInfo.asset_name;
+        }
+      }
+
+      const result = { displayName };
+
+      // Cache for 1 hour
+      this.assetMetadataCache.set(cacheKey, result, 3600);
+
+      return result;
+    } catch (error) {
+      this.logger.error(`Error fetching asset metadata for unit ${unit}: ${error.message}`);
+
+      // Handle Blockfrost-specific errors
+      if (error.status_code === 404) {
+        throw new NotFoundException(`Asset with unit ${unit} not found on-chain`);
+      }
+
+      throw new InternalServerErrorException(`Failed to fetch asset metadata: ${error.message}`);
     }
   }
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -1,4 +1,4 @@
-﻿import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
+import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
 import {
   BadRequestException,
   ForbiddenException,
@@ -987,6 +987,7 @@ export class GovernanceService {
                     policy_id: exactAsset.policyId,
                     asset_id: exactAsset.assetName,
                     status: AssetStatus.OFFERED,
+                    origin_type: AssetOriginType.OFFERED,
                     deleted: false,
                   },
                   select: ['id', 'name'],
@@ -1025,6 +1026,7 @@ export class GovernanceService {
                 select: [
                   'id',
                   'status',
+                  'origin_type',
                   'type',
                   'policy_id',
                   'asset_id',
@@ -1054,10 +1056,52 @@ export class GovernanceService {
                 );
               }
 
+              if (offeredAsset.origin_type !== AssetOriginType.OFFERED) {
+                throw new BadRequestException(
+                  `Asset "${offeredAsset.name || action.assetId}" is not an active vault offer. Only OFFERED-origin assets can be cancelled.`
+                );
+              }
+
               if (!offeredAsset.listing_tx_hash) {
                 throw new BadRequestException(
                   `Asset "${offeredAsset.name || action.assetId}" is missing offer transaction reference. Cannot create cancel-offer proposal.`
                 );
+              }
+
+              if (this.isMainnet) {
+                const treasuryWallet = await this.treasuryWalletService.getTreasuryWallet(vaultId);
+                if (!treasuryWallet?.address) {
+                  throw new BadRequestException(
+                    'Treasury wallet is not configured for this vault. Cannot verify offer status on WayUp.'
+                  );
+                }
+
+                try {
+                  const offerState = await this.wayUpPricingService.getVaultOfferMarketplaceState(
+                    treasuryWallet.address,
+                    offeredAsset.policy_id,
+                    offeredAsset.asset_id
+                  );
+
+                  if (offerState !== 'active') {
+                    const assetLabel = offeredAsset.name || action.assetId;
+                    throw new BadRequestException(
+                      this.wayUpPricingService.getOfferResolutionUserMessage(offerState, assetLabel) +
+                        ' Cancel-offer proposal cannot be created.'
+                    );
+                  }
+                } catch (error) {
+                  if (error instanceof BadRequestException) {
+                    throw error;
+                  }
+
+                  const errorMessage = error instanceof Error ? error.message : String(error);
+                  this.logger.error(
+                    `Failed to verify offer status on WayUp for asset ${offeredAsset.id}: ${errorMessage}`,
+                    error instanceof Error ? error.stack : undefined
+                  );
+                  throw new BadRequestException('Unable to verify offer status on WayUp. Please try again later.');
+                }
               }
 
               const offerPriceAda = Number(offeredAsset.listing_price ?? offeredAsset.floor_price ?? 0);
@@ -2811,6 +2855,7 @@ export class GovernanceService {
         .where('asset.vault_id = :vaultId', { vaultId })
         .andWhere('asset.type = :type', { type: AssetType.NFT })
         .andWhere('asset.status = :status', { status: AssetStatus.OFFERED })
+        .andWhere('asset.origin_type = :originType', { originType: AssetOriginType.OFFERED })
         .andWhere('asset.deleted = :deleted', { deleted: false })
         .andWhere('asset.listing_tx_hash IS NOT NULL');
 
@@ -3324,3 +3369,5 @@ export class GovernanceService {
     return BigInt(intPart + fracPart.padEnd(decimals, '0').slice(0, decimals));
   }
 }
+
+export default GovernanceService;

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -149,7 +149,7 @@ export class GovernanceService {
     this.adminAddress = this.configService.get<string>('ADMIN_ADDRESS');
 
     this.blockfrost = new BlockFrostAPI({
-      projectId: this.configService.get<string>('BLOCKFROST_API_KEY_MAINNET'),
+      projectId: this.configService.get<string>('BLOCKFROST_API_KEY'),
     });
     this.votingPowerCache = new NodeCache({
       stdTTL: this.CACHE_TTL.VOTING_POWER,
@@ -451,6 +451,7 @@ export class GovernanceService {
         'assets_whitelist',
         'is_expandable_asset_whitelist',
       ],
+      relations: ['assets_whitelist'],
     });
 
     if (!vault) {

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -3361,11 +3361,11 @@ export class GovernanceService {
    * Returns display name only
    */
   async getAssetMetadataByUnit(unit: string): Promise<{ displayName: string }> {
-    // Validate unit format: at least 56 hex characters (policy ID)
-    const hexPattern = /^[a-fA-F0-9]{56,}$/;
+    // Validate unit format: 56 hex chars for policy ID + optional hex asset name (even-length)
+    const hexPattern = /^[a-fA-F0-9]{56}([a-fA-F0-9]{2})*$/;
     if (!unit || !hexPattern.test(unit)) {
       throw new BadRequestException(
-        'Invalid asset unit format. Must be at least 56 hexadecimal characters (policy ID + optional asset name)'
+        'Invalid asset unit format. Must be 56 hexadecimal characters (policy ID) plus an optional even-length hex asset name'
       );
     }
 

--- a/src/modules/vaults/phase-management/governance/governance.service.ts
+++ b/src/modules/vaults/phase-management/governance/governance.service.ts
@@ -631,6 +631,42 @@ export class GovernanceService {
               );
             }
           }
+
+          // Check that new OFFER actions don't conflict with existing CANCEL_OFFER proposals for
+          // the same NFT (identified by policy_id + asset_id). An active cancel-offer proposal
+          // means the vault is in the process of withdrawing a prior offer on that NFT — creating
+          // a new offer on the same NFT while cancellation is pending would cause conflicting
+          // on-chain operations.
+          if (requestedOfferAssetIds.length > 0) {
+            const existingCancelOfferDbAssetIds = existingActions
+              .filter((a: any) => a.exec === ExecType.CANCEL_OFFER)
+              .map((a: any) => a.assetId);
+
+            if (existingCancelOfferDbAssetIds.length > 0) {
+              const cancelOfferAssets = await this.assetRepository.find({
+                where: { id: In(existingCancelOfferDbAssetIds) },
+                select: ['id', 'policy_id', 'asset_id', 'name'],
+              });
+
+              for (const action of requestedActions.filter((a: any) => a.exec === ExecType.OFFER)) {
+                const policyId = action.assetId.length >= 56 ? action.assetId.slice(0, 56) : action.assetId;
+                const hexAssetName = action.assetId.length > 56 ? action.assetId.slice(56) : null;
+
+                const conflict = cancelOfferAssets.find(
+                  ca =>
+                    ca.policy_id.toLowerCase() === policyId.toLowerCase() &&
+                    (!hexAssetName || ca.asset_id.toLowerCase() === hexAssetName.toLowerCase())
+                );
+
+                if (conflict) {
+                  throw new BadRequestException(
+                    `Cannot create offer proposal. NFT "${conflict.name || policyId}" already has an active cancel-offer proposal "${existingProposal.title}". ` +
+                      `Please wait for that cancel-offer proposal to complete before placing a new offer on this NFT.`
+                  );
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1004,6 +1040,13 @@ export class GovernanceService {
                 if (!action.price || isNaN(parseFloat(action.price)) || parseFloat(action.price) <= 0) {
                   throw new BadRequestException(
                     `Offer price is required and must be greater than 0 for OFFER action on NFT ${action.assetName || action.assetId}.`
+                  );
+                }
+
+                const MIN_OFFER_PRICE_ADA = 5;
+                if (parseFloat(action.price) < MIN_OFFER_PRICE_ADA) {
+                  throw new BadRequestException(
+                    `Minimum offer price is ${MIN_OFFER_PRICE_ADA} ADA for NFT ${action.assetName || action.assetId}.`
                   );
                 }
 
@@ -2184,9 +2227,9 @@ export class GovernanceService {
     // Transform marketplace actions with enriched asset data and WayUp URLs
     // For DexHunter swaps, combine quantities by token (policy_id + asset_id)
     const marketplaceActions = (proposal.metadata?.marketplaceActions || []).map(action => {
-      const isBuy = action.exec === 'BUY';
-      const isOffer = action.exec === 'OFFER';
-      const isCancelOffer = action.exec === 'CANCEL_OFFER';
+      const isBuy = action.exec === ExecType.BUY;
+      const isOffer = action.exec === ExecType.OFFER;
+      const isCancelOffer = action.exec === ExecType.CANCEL_OFFER;
       const isSwapAction = action.slippage !== undefined || action.market === 'DexHunter';
 
       if (isBuy || isOffer || isCancelOffer) {

--- a/src/modules/vaults/phase-management/governance/snapshot.module.ts
+++ b/src/modules/vaults/phase-management/governance/snapshot.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { SnapshotService } from './snapshot.service';
+
+import { Snapshot } from '@/database/snapshot.entity';
+import { User } from '@/database/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Snapshot, User])],
+  providers: [SnapshotService],
+  exports: [SnapshotService],
+})
+export class SnapshotModule {}

--- a/src/modules/vaults/phase-management/governance/snapshot.service.ts
+++ b/src/modules/vaults/phase-management/governance/snapshot.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
+import { Snapshot } from '@/database/snapshot.entity';
 import { User } from '@/database/user.entity';
 
 /**
@@ -11,6 +12,8 @@ import { User } from '@/database/user.entity';
 @Injectable()
 export class SnapshotService {
   constructor(
+    @InjectRepository(Snapshot)
+    private readonly snapshotsRepository: Repository<Snapshot>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>
   ) {}
@@ -35,5 +38,22 @@ export class SnapshotService {
 
     // Deduplicate user IDs (though DB should already ensure uniqueness)
     return [...new Set(users.map(u => u.id))];
+  }
+
+  /**
+   * Fetch the latest snapshot for a vault and return token holder IDs.
+   * Returns empty array if no snapshot exists.
+   *
+   * @param vaultId - The vault ID to fetch snapshot for
+   * @returns Array of unique user IDs from the latest snapshot
+   */
+  async getTokenHolderIdsFromLatestSnapshot(vaultId: string): Promise<string[]> {
+    const snapshot = await this.snapshotsRepository.findOne({
+      where: { vaultId },
+      order: { createdAt: 'DESC' },
+      select: ['addressBalances'],
+    });
+
+    return this.getTokenHolderIdsFromSnapshot(snapshot?.addressBalances);
   }
 }

--- a/src/modules/vaults/processing-tx/onchain/blockchain.service.ts
+++ b/src/modules/vaults/processing-tx/onchain/blockchain.service.ts
@@ -463,7 +463,7 @@ export class BlockchainService {
   async buildWayUpTransaction(input: WayUpTransactionInput): Promise<WayUpTransactionBuildResponse> {
     try {
       this.logger.log('Building WayUp transaction with input:', input);
-      const response = await fetch(`https://prod.api.ada-anvil.app/marketplace/api/build-tx`, {
+      const response = await fetch(`https://prod.api.ada-anvil.app/v2/services/marketplace/transactions/build`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -867,7 +867,7 @@ export class VaultsService {
         statuses: [AssetStatus.PENDING, AssetStatus.LOCKED, AssetStatus.EXTRACTED, AssetStatus.OFFERED],
       })
       .andWhere('asset.origin_type IN (:...originTypes)', {
-        originTypes: [AssetOriginType.CONTRIBUTED, AssetOriginType.BOUGHT],
+        originTypes: [AssetOriginType.CONTRIBUTED, AssetOriginType.BOUGHT, AssetOriginType.OFFERED],
       })
       .setParameters({
         nftType: AssetType.NFT,

--- a/src/modules/wayup/wayup-pricing.service.ts
+++ b/src/modules/wayup/wayup-pricing.service.ts
@@ -285,9 +285,12 @@ export class WayUpPricingService {
    * Fetch NFTs held by a treasury wallet from Anvil marketplace API.
    */
   async getWalletAssets(walletAddress: string): Promise<AnvilWalletAsset[]> {
+    if (!this.anvilApiKey) {
+      throw new Error('ANVIL_API_KEY is not configured');
+    }
+
     const allAssets: AnvilWalletAsset[] = [];
     let cursor: string | undefined;
-
     do {
       const params = new URLSearchParams({ limit: '60' });
       if (cursor) {

--- a/src/modules/wayup/wayup-pricing.service.ts
+++ b/src/modules/wayup/wayup-pricing.service.ts
@@ -5,11 +5,19 @@ import { InjectRepository } from '@nestjs/typeorm';
 import NodeCache from 'node-cache';
 import { Repository } from 'typeorm';
 
-import { GetCollectionAssetsQuery, GetCollectionAssetsResponse } from './wayup.types';
+import {
+  AnvilWalletAsset,
+  AnvilWalletOffer,
+  AnvilWalletOffersResponse,
+  AnvilWalletAssetsResponse,
+  GetCollectionAssetsQuery,
+  GetCollectionAssetsResponse,
+  OfferResolutionStatus,
+} from './wayup.types';
 
 import { Asset } from '@/database/asset.entity';
 import { AssetsService } from '@/modules/vaults/assets/assets.service';
-import { AssetStatus } from '@/types/asset.types';
+import { AssetOriginType, AssetStatus } from '@/types/asset.types';
 
 /**
  * WayUp Pricing Service - Handles only pricing queries without transaction building
@@ -19,12 +27,15 @@ import { AssetStatus } from '@/types/asset.types';
 export class WayUpPricingService {
   private readonly logger = new Logger(WayUpPricingService.name);
   private readonly baseUrl = 'https://prod.api.ada-anvil.app/marketplace/api/get-collection-assets';
+  private readonly anvilMarketplaceApi: string;
+  private readonly anvilApiKey: string;
   private readonly isMainnet: boolean;
   private readonly tapToolsApiKey: string;
   private readonly tapToolsApiUrl: string;
   private floorPriceCache = new NodeCache({ stdTTL: 300 }); // 5 minute cache for floor prices
 
   private isTrackingInProgress = false;
+  private isOfferTrackingInProgress = false;
 
   constructor(
     private readonly configService: ConfigService,
@@ -35,6 +46,9 @@ export class WayUpPricingService {
     this.isMainnet = this.configService.get<string>('CARDANO_NETWORK') === 'mainnet';
     this.tapToolsApiKey = this.configService.get<string>('TAPTOOLS_API_KEY');
     this.tapToolsApiUrl = this.configService.get<string>('TAPTOOLS_API_URL');
+    const anvilApiUrl = this.configService.get<string>('ANVIL_API_URL') ?? 'https://prod.api.ada-anvil.app/v2';
+    this.anvilMarketplaceApi = `${anvilApiUrl.replace(/\/$/, '')}/services/marketplace`;
+    this.anvilApiKey = this.configService.get<string>('ANVIL_API_KEY') ?? '';
   }
 
   /**
@@ -229,6 +243,255 @@ export class WayUpPricingService {
   }
 
   /**
+   * Fetch all sent offers for a treasury wallet from Anvil marketplace API.
+   * @see https://prod.api.ada-anvil.app/v2/services/swagger/ui#tag/marketplace/GET/marketplace/wallets/{address}/offers
+   */
+  async getWalletSentOffers(walletAddress: string): Promise<AnvilWalletOffer[]> {
+    const allOffers: AnvilWalletOffer[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const params = new URLSearchParams({
+        direction: 'sent',
+        limit: '60',
+      });
+      if (cursor) {
+        params.append('cursor', cursor);
+      }
+
+      const response = await fetch(
+        `${this.anvilMarketplaceApi}/wallets/${encodeURIComponent(walletAddress)}/offers?${params.toString()}`,
+        {
+          headers: {
+            'x-api-key': this.anvilApiKey,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Anvil wallet offers API error: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      const data: AnvilWalletOffersResponse = await response.json();
+      allOffers.push(...(data.results ?? []));
+      cursor = data.cursor;
+    } while (cursor);
+
+    return allOffers;
+  }
+
+  /**
+   * Fetch NFTs held by a treasury wallet from Anvil marketplace API.
+   */
+  async getWalletAssets(walletAddress: string): Promise<AnvilWalletAsset[]> {
+    const allAssets: AnvilWalletAsset[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const params = new URLSearchParams({ limit: '60' });
+      if (cursor) {
+        params.append('cursor', cursor);
+      }
+
+      const response = await fetch(
+        `${this.anvilMarketplaceApi}/wallets/${encodeURIComponent(walletAddress)}/assets?${params.toString()}`,
+        {
+          headers: {
+            'x-api-key': this.anvilApiKey,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Anvil wallet assets API error: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      const data: AnvilWalletAssetsResponse = await response.json();
+      allAssets.push(...(data.results ?? []));
+      cursor = data.cursor;
+    } while (cursor);
+
+    return allAssets;
+  }
+
+  offerAssetKey(policyId: string, assetName: string): string {
+    return `${policyId.toLowerCase()}:${assetName.toLowerCase()}`;
+  }
+
+  /**
+   * Resolve a single vault offer against live Anvil marketplace state.
+   */
+  async getVaultOfferMarketplaceState(
+    treasuryAddress: string,
+    policyId: string,
+    assetNameHex: string
+  ): Promise<OfferResolutionStatus> {
+    const [sentOffers, treasuryAssets] = await Promise.all([
+      this.getWalletSentOffers(treasuryAddress),
+      this.getWalletAssets(treasuryAddress),
+    ]);
+
+    const activeOfferKeys = new Set(sentOffers.map(offer => this.offerAssetKey(offer.policyId, offer.assetName)));
+    const treasuryAssetKeys = new Set(treasuryAssets.map(asset => this.offerAssetKey(asset.policyId, asset.assetName)));
+
+    return this.resolveOfferStatus(policyId, assetNameHex, activeOfferKeys, treasuryAssetKeys);
+  }
+
+  getOfferResolutionUserMessage(state: OfferResolutionStatus, assetLabel: string): string {
+    switch (state) {
+      case 'active':
+        return `Offer for ${assetLabel} is active on WayUp.`;
+      case 'accepted':
+        return `Offer for ${assetLabel} was already accepted — the NFT is in the treasury wallet.`;
+      case 'cancelled':
+        return `Offer for ${assetLabel} is no longer active on WayUp (cancelled or expired).`;
+    }
+  }
+
+  /**
+   * Determine whether a vault offer is still active, was accepted, or was cancelled.
+   */
+  resolveOfferStatus(
+    policyId: string,
+    assetNameHex: string,
+    activeOfferKeys: Set<string>,
+    treasuryAssetKeys: Set<string>
+  ): OfferResolutionStatus {
+    const key = this.offerAssetKey(policyId, assetNameHex);
+
+    if (activeOfferKeys.has(key)) {
+      return 'active';
+    }
+
+    if (treasuryAssetKeys.has(key)) {
+      return 'accepted';
+    }
+
+    return 'cancelled';
+  }
+
+  /**
+   * Reconcile active offers in the database with Anvil marketplace state.
+   * - Active sent offer → keep OFFERED status / OFFERED origin
+   * - Offer gone + NFT in treasury → accepted → BOUGHT origin + EXTRACTED status
+   * - Offer gone + NFT not in treasury → cancelled → CANCEL_OFFER status
+   */
+  async syncOfferStatuses(): Promise<{
+    checked: number;
+    accepted: number;
+    cancelled: number;
+    stillActive: number;
+  }> {
+    const offeredAssets = await this.assetRepository.find({
+      where: {
+        status: AssetStatus.OFFERED,
+        origin_type: AssetOriginType.OFFERED,
+        deleted: false,
+      },
+      relations: ['vault', 'vault.treasury_wallet'],
+      select: {
+        id: true,
+        policy_id: true,
+        asset_id: true,
+        name: true,
+        vault_id: true,
+        vault: {
+          id: true,
+          treasury_wallet: {
+            treasury_address: true,
+          },
+        },
+      },
+    });
+
+    if (offeredAssets.length === 0) {
+      return { checked: 0, accepted: 0, cancelled: 0, stillActive: 0 };
+    }
+
+    const assetsByTreasury = new Map<string, Asset[]>();
+
+    for (const asset of offeredAssets) {
+      const treasuryAddress = asset.vault?.treasury_wallet?.treasury_address;
+      if (!treasuryAddress) {
+        this.logger.warn(`Skipping offer asset ${asset.id}: vault ${asset.vault_id} has no treasury wallet`);
+        continue;
+      }
+
+      const group = assetsByTreasury.get(treasuryAddress) ?? [];
+      group.push(asset);
+      assetsByTreasury.set(treasuryAddress, group);
+    }
+
+    const acceptedIds: string[] = [];
+    const cancelledIds: string[] = [];
+    let stillActive = 0;
+
+    for (const [treasuryAddress, assets] of assetsByTreasury) {
+      try {
+        const [sentOffers, treasuryAssets] = await Promise.all([
+          this.getWalletSentOffers(treasuryAddress),
+          this.getWalletAssets(treasuryAddress),
+        ]);
+
+        const activeOfferKeys = new Set(sentOffers.map(offer => this.offerAssetKey(offer.policyId, offer.assetName)));
+        const treasuryAssetKeys = new Set(
+          treasuryAssets.map(asset => this.offerAssetKey(asset.policyId, asset.assetName))
+        );
+
+        for (const asset of assets) {
+          const resolution = this.resolveOfferStatus(
+            asset.policy_id,
+            asset.asset_id,
+            activeOfferKeys,
+            treasuryAssetKeys
+          );
+
+          switch (resolution) {
+            case 'active':
+              stillActive++;
+              break;
+            case 'accepted':
+              acceptedIds.push(asset.id);
+              this.logger.log(
+                `Offer accepted for "${asset.name}" (${asset.policy_id}${asset.asset_id}) in treasury ${treasuryAddress}`
+              );
+              break;
+            case 'cancelled':
+              cancelledIds.push(asset.id);
+              this.logger.log(
+                `Offer cancelled for "${asset.name}" (${asset.policy_id}${asset.asset_id}) from treasury ${treasuryAddress}`
+              );
+              break;
+          }
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        this.logger.error(
+          `Failed to sync offer statuses for treasury ${treasuryAddress}: ${errorMessage}`,
+          error instanceof Error ? error.stack : undefined
+        );
+      }
+    }
+
+    if (acceptedIds.length > 0) {
+      await this.assetsService.markOffersAsAccepted(acceptedIds);
+    }
+
+    if (cancelledIds.length > 0) {
+      await this.assetsService.markOffersAsCancelled(cancelledIds);
+    }
+
+    return {
+      checked: offeredAssets.length,
+      accepted: acceptedIds.length,
+      cancelled: cancelledIds.length,
+      stillActive,
+    };
+  }
+
+  /**
    * Cron job that tracks NFT sales by checking if LISTED assets are still on WayUp
    * Implements locking mechanism to prevent concurrent executions
    */
@@ -306,6 +569,50 @@ export class WayUpPricingService {
     } finally {
       // Release lock
       this.isTrackingInProgress = false;
+    }
+  }
+
+  /**
+   * Cron job that reconciles OFFERED assets with Anvil marketplace wallet offers.
+   * Detects accepted offers (NFT in treasury) and cancelled offers (no longer sent).
+   */
+  @Cron(CronExpression.EVERY_30_MINUTES)
+  async trackOfferStatuses(): Promise<void> {
+    if (!this.isMainnet) {
+      this.logger.debug('Skipping offer status tracking for testnet');
+      return;
+    }
+
+    if (!this.anvilApiKey) {
+      this.logger.warn('Skipping offer status tracking: ANVIL_API_KEY is not configured');
+      return;
+    }
+
+    if (this.isOfferTrackingInProgress) {
+      this.logger.warn('Offer status tracking is already in progress, skipping this execution');
+      return;
+    }
+
+    this.isOfferTrackingInProgress = true;
+
+    try {
+      const result = await this.syncOfferStatuses();
+
+      if (result.checked === 0) {
+        this.logger.log('No offered assets found to track');
+        return;
+      }
+
+      this.logger.log(
+        `Offer status tracking completed: checked=${result.checked}, active=${result.stillActive}, ` +
+          `accepted=${result.accepted}, cancelled=${result.cancelled}`
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorStack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`Offer status tracking cron job failed: ${errorMessage}`, errorStack);
+    } finally {
+      this.isOfferTrackingInProgress = false;
     }
   }
 }

--- a/src/modules/wayup/wayup-pricing.service.ts
+++ b/src/modules/wayup/wayup-pricing.service.ts
@@ -247,9 +247,12 @@ export class WayUpPricingService {
    * @see https://prod.api.ada-anvil.app/v2/services/swagger/ui#tag/marketplace/GET/marketplace/wallets/{address}/offers
    */
   async getWalletSentOffers(walletAddress: string): Promise<AnvilWalletOffer[]> {
+    if (!this.anvilApiKey) {
+      throw new Error('ANVIL_API_KEY is not configured');
+    }
+
     const allOffers: AnvilWalletOffer[] = [];
     let cursor: string | undefined;
-
     do {
       const params = new URLSearchParams({
         direction: 'sent',

--- a/src/modules/wayup/wayup.service.ts
+++ b/src/modules/wayup/wayup.service.ts
@@ -595,6 +595,7 @@ export class WayUpService {
     summary: {
       listedCount: number;
       unlistedCount: number;
+      unlistedOffersCount: number;
       updatedCount: number;
       offersCount: number;
       purchasedCount: number;
@@ -606,6 +607,7 @@ export class WayUpService {
     const hasActions =
       (actions.listings?.length ?? 0) > 0 ||
       (actions.unlistings?.length ?? 0) > 0 ||
+      (actions.unlistOffers?.length ?? 0) > 0 ||
       (actions.updates?.length ?? 0) > 0 ||
       (actions.offers?.length ?? 0) > 0 ||
       (actions.purchases?.length ?? 0) > 0;
@@ -624,6 +626,7 @@ export class WayUpService {
         summary: {
           listedCount: actions.listings?.length ?? 0,
           unlistedCount: actions.unlistings?.length ?? 0,
+          unlistedOffersCount: actions.unlistOffers?.length ?? 0,
           updatedCount: actions.updates?.length ?? 0,
           offersCount: actions.offers?.length ?? 0,
           purchasedCount: actions.purchases?.length ?? 0,
@@ -709,6 +712,7 @@ export class WayUpService {
       const actionParts: string[] = [];
       if (actions.listings?.length) actionParts.push(`listing ${actions.listings.length} NFT(s)`);
       if (actions.unlistings?.length) actionParts.push(`unlisting ${actions.unlistings.length}`);
+      if (actions.unlistOffers?.length) actionParts.push(`unlisting ${actions.unlistOffers.length} offer(s)`);
       if (actions.updates?.length) actionParts.push(`updating ${actions.updates.length}`);
       if (actions.offers?.length) actionParts.push(`offering on ${actions.offers.length}`);
       if (actions.purchases?.length) actionParts.push(`buying ${actions.purchases.length}`);
@@ -784,6 +788,11 @@ export class WayUpService {
         combinedPayload.createOffer = actions.offers;
       }
 
+      // Add unlist offers if provided
+      if (actions.unlistOffers?.length > 0) {
+        combinedPayload.unlistOffer = actions.unlistOffers;
+      }
+
       // Add purchases if provided
       if (actions.purchases?.length > 0) {
         combinedPayload.buy = actions.purchases;
@@ -793,6 +802,7 @@ export class WayUpService {
         `Building combined transaction: ` +
           `${actions.listings?.length ?? 0} listings, ` +
           `${actions.unlistings?.length ?? 0} unlistings, ` +
+          `${actions.unlistOffers?.length ?? 0} unlist offers, ` +
           `${actions.updates?.length ?? 0} updates, ` +
           `${actions.offers?.length ?? 0} offers, ` +
           `${actions.purchases?.length ?? 0} purchases`
@@ -814,6 +824,7 @@ export class WayUpService {
       const summary = {
         listedCount: actions.listings?.length ?? 0,
         unlistedCount: actions.unlistings?.length ?? 0,
+        unlistedOffersCount: actions.unlistOffers?.length ?? 0,
         updatedCount: actions.updates?.length ?? 0,
         offersCount: actions.offers?.length ?? 0,
         purchasedCount: actions.purchases?.length ?? 0,

--- a/src/modules/wayup/wayup.service.ts
+++ b/src/modules/wayup/wayup.service.ts
@@ -691,16 +691,9 @@ export class WayUpService {
           amount: 1,
         })) ?? [];
 
-      // Calculate total ADA needed from treasury for offers and purchases
-      const offerAmount = (actions.offers?.reduce((sum, o) => sum + o.priceAda, 0) ?? 0) * 1_000_000;
-      const purchaseAmount = (actions.purchases?.reduce((sum, p) => sum + p.priceAda, 0) ?? 0) * 1_000_000;
-      const totalTreasuryAda = offerAmount + purchaseAmount;
-
       // Get treasury UTXOs - treasury provides NFTs, ADA for offers/purchases, and transaction fees
       const result = await getUtxosExtract(Address.from_bech32(treasuryAddress), this.blockfrost, {
         targetAssets: targetAssets.length > 0 ? targetAssets : undefined,
-        targetAdaAmount: totalTreasuryAda > 0 ? totalTreasuryAda : undefined,
-        maxUtxos: 20,
       });
       const treasuryUtxos = result.utxos;
 

--- a/src/modules/wayup/wayup.service.ts
+++ b/src/modules/wayup/wayup.service.ts
@@ -787,15 +787,26 @@ export class WayUpService {
 
         for (const unlistOffer of actions.unlistOffers) {
           try {
-            // Find the output index for this offer (like unlistings and updates)
-            const outputIndex = await this.findListingOutputIndex(
-              unlistOffer.txHashIndex,
-              unlistOffer.policyId,
-              unlistOffer.assetName
-            );
+            let txHashIndexWithOutput: string;
+
+            // Check if txHashIndex already includes the output index (format: txHash#outputIndex)
+            if (unlistOffer.txHashIndex.includes('#')) {
+              // Already has the output index, use it directly
+              txHashIndexWithOutput = unlistOffer.txHashIndex;
+              this.logger.log(`Using pre-formatted txHashIndex for offer cancel: ${txHashIndexWithOutput}`);
+            } else {
+              // Need to find the output index
+              const outputIndex = await this.findListingOutputIndex(
+                unlistOffer.txHashIndex,
+                unlistOffer.policyId,
+                unlistOffer.assetName
+              );
+              txHashIndexWithOutput = `${unlistOffer.txHashIndex}#${outputIndex}`;
+            }
+
             unlistOffersWithIndices.push({
               policyId: unlistOffer.policyId,
-              txHashIndex: `${unlistOffer.txHashIndex}#${outputIndex}`,
+              txHashIndex: txHashIndexWithOutput,
             });
           } catch (error) {
             this.logger.error(`Failed to find output index for offer cancel ${unlistOffer.policyId}: ${error.message}`);

--- a/src/modules/wayup/wayup.service.ts
+++ b/src/modules/wayup/wayup.service.ts
@@ -788,9 +788,29 @@ export class WayUpService {
         combinedPayload.createOffer = actions.offers;
       }
 
-      // Add unlist offers if provided
+      // Add unlist offers if provided (need to find output indices)
       if (actions.unlistOffers?.length > 0) {
-        combinedPayload.unlistOffer = actions.unlistOffers;
+        const unlistOffersWithIndices: { policyId: string; txHashIndex: string }[] = [];
+
+        for (const unlistOffer of actions.unlistOffers) {
+          try {
+            // Find the output index for this offer (like unlistings and updates)
+            const outputIndex = await this.findListingOutputIndex(
+              unlistOffer.txHashIndex,
+              unlistOffer.policyId,
+              unlistOffer.assetName
+            );
+            unlistOffersWithIndices.push({
+              policyId: unlistOffer.policyId,
+              txHashIndex: `${unlistOffer.txHashIndex}#${outputIndex}`,
+            });
+          } catch (error) {
+            this.logger.error(`Failed to find output index for offer cancel ${unlistOffer.policyId}: ${error.message}`);
+            throw new Error(`Cannot cancel offer ${unlistOffer.policyId}: ${error.message}`);
+          }
+        }
+
+        combinedPayload.unlistOffer = unlistOffersWithIndices;
       }
 
       // Add purchases if provided

--- a/src/modules/wayup/wayup.types.ts
+++ b/src/modules/wayup/wayup.types.ts
@@ -40,7 +40,8 @@ export interface MakeOfferInput {
  */
 export interface BuyNFTInput {
   policyId: string;
-  txHashIndex: string; // Format: txHash#outputIndex
+  /** Format: txHash#outputIndex */
+  txHashIndex: string;
   priceAda: number;
 }
 

--- a/src/modules/wayup/wayup.types.ts
+++ b/src/modules/wayup/wayup.types.ts
@@ -227,3 +227,34 @@ export interface GetCollectionAssetsResponse {
   pageState: string | null;
   count: number;
 }
+
+/** Offer returned by Anvil GET /marketplace/wallets/{address}/offers */
+export interface AnvilWalletOffer {
+  policyId: string;
+  assetName: string;
+  price: number;
+  priceCurrency: string;
+  outputRef: string;
+  offererStakeKeyhash?: string;
+  receiverStakeKeyhash?: string;
+}
+
+export interface AnvilWalletOffersResponse {
+  results: AnvilWalletOffer[];
+  cursor?: string;
+}
+
+/** Asset held in wallet from Anvil GET /marketplace/wallets/{address}/assets */
+export interface AnvilWalletAsset {
+  policyId: string;
+  assetName: string;
+  unit: string;
+  name?: string;
+}
+
+export interface AnvilWalletAssetsResponse {
+  results: AnvilWalletAsset[];
+  cursor?: string;
+}
+
+export type OfferResolutionStatus = 'active' | 'accepted' | 'cancelled';

--- a/src/modules/wayup/wayup.types.ts
+++ b/src/modules/wayup/wayup.types.ts
@@ -111,6 +111,7 @@ export interface BuyNFTPayload {
 export interface CombinedMarketplaceActionsInput {
   listings?: NFTListingInput[]; // NFTs to list for sale
   unlistings?: UnlistInput[]; // Listings to cancel
+  unlistOffers?: Array<{ policyId: string; txHashIndex: string }>; // Offers to cancel
   updates?: UpdateListingInput[]; // Listings to update price
   offers?: MakeOfferInput[]; // Offers to make
   purchases?: BuyNFTInput[]; // NFTs to buy
@@ -141,6 +142,10 @@ export interface WayUpTransactionInput {
     policyId: string;
     assetName: string;
     priceAda: number;
+  }[];
+  unlistOffer?: {
+    policyId: string;
+    txHashIndex: string;
   }[];
   buy?: {
     policyId: string;

--- a/src/modules/wayup/wayup.types.ts
+++ b/src/modules/wayup/wayup.types.ts
@@ -112,7 +112,7 @@ export interface BuyNFTPayload {
 export interface CombinedMarketplaceActionsInput {
   listings?: NFTListingInput[]; // NFTs to list for sale
   unlistings?: UnlistInput[]; // Listings to cancel
-  unlistOffers?: Array<{ policyId: string; txHashIndex: string }>; // Offers to cancel
+  unlistOffers?: Array<{ policyId: string; assetName: string; txHashIndex: string }>; // Offers to cancel (assetName required for output index lookup)
   updates?: UpdateListingInput[]; // Listings to update price
   offers?: MakeOfferInput[]; // Offers to make
   purchases?: BuyNFTInput[]; // NFTs to buy

--- a/src/types/asset.types.ts
+++ b/src/types/asset.types.ts
@@ -18,7 +18,10 @@ export enum AssetStatus {
   LISTED = 'listed',
   SOLD = 'sold',
   BURNED = 'burned',
+  /** Active marketplace offer placed by vault treasury */
   OFFERED = 'offered',
+  /** Offer was canceled or rejected on WayUp */
+  CANCEL_OFFER = 'cancel_offer',
 }
 
 export enum AssetOriginType {
@@ -26,6 +29,7 @@ export enum AssetOriginType {
   CONTRIBUTED = 'contributed',
   FEE = 'fee',
   BOUGHT = 'bought',
+  OFFERED = 'offered',
 }
 
 export enum AssetValuationMethod {

--- a/src/types/proposal.types.ts
+++ b/src/types/proposal.types.ts
@@ -31,4 +31,6 @@ export enum MarketplaceAction {
   UPDATE_LISTING = 'update_listing',
   UNLIST = 'unlist',
   BUY = 'buy',
+  OFFER = 'offer',
+  CANCEL_OFFER = 'cancel_offer',
 }


### PR DESCRIPTION
This pull request introduces support for tracking and managing "offered" NFT assets and their offer lifecycle (acceptance and cancellation) within the vault system. It adds new asset statuses and origin types, updates asset status handling, implements offer acceptance/cancellation logic, and improves alerting and notification for marketplace operations. Additionally, it includes some refactoring and dependency injection improvements.

**Offer Lifecycle Management**

- Added new asset status `cancel_offer` and origin type `offered` to the database enums, with a migration to support these changes. This enables explicit tracking of assets that have been offered and those whose offers have been cancelled.
- Implemented `markOffersAsAccepted` and `markOffersAsCancelled` methods in `AssetsService` to handle offer acceptance and cancellation. These methods update asset statuses, adjust vault cost accounting, and emit events for notifications.
- Updated asset queries and filtering logic to include the new `offered` origin type and status, ensuring these assets are displayed and managed correctly in vault asset lists. [[1]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7R34-R54) [[2]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7L231-R257) [[3]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7L391-R408)

**Notifications and Alerts**

- Added event listeners for `offer.accepted` and `offer.cancelled` events, sending bulk notifications to token holders when offers are accepted or cancelled.
- Enhanced the `AlertsService` with a new alert type for insufficient treasury funds during marketplace operations, and ensured alerts are skipped in development environments. [[1]](diffhunk://#diff-f0b44e5cbb0d55d959e38da867daccf01767e23fbea1e61a67185dafdcf2b77fR592-R675) [[2]](diffhunk://#diff-f0b44e5cbb0d55d959e38da867daccf01767e23fbea1e61a67185dafdcf2b77fR25-R33) [[3]](diffhunk://#diff-f0b44e5cbb0d55d959e38da867daccf01767e23fbea1e61a67185dafdcf2b77fR48-R52)

**Database and Entity Enhancements**

- Updated the `Asset` entity to use a numeric transformer for `listing_price` and clarified the meaning of `listingTxHash` for listed and offered assets.

**Dependency Injection and Imports**

- Injected `SnapshotService` and `SnapshotModule` into the assets module and service for future extensibility. [[1]](diffhunk://#diff-a8d8ff648e3af852cc7e824c3c237fd2e4d9343e9608c84e814f9064a939e550R16-R23) [[2]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7R23) [[3]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7L51-R74)
- Fixed import style for `GovernanceService` for consistency.

**Other Improvements**

- Added clarifying comments and documentation for proposal and marketplace action data structures. [[1]](diffhunk://#diff-f1d2ee1938a84dcb93f27fbe5e3a470075df87a0c5634edb4d725140e7b3970eL85-R85) [[2]](diffhunk://#diff-f1d2ee1938a84dcb93f27fbe5e3a470075df87a0c5634edb4d725140e7b3970eR102-R110)

**References:**  
[[1]](diffhunk://#diff-e669d96964ad82dd96b3ed1407c2f9f340518a1a3fd6fd8fe80a464ceef8f017R1-R53) [[2]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7R729-R857) [[3]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7R34-R54) [[4]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7L231-R257) [[5]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7L391-R408) [[6]](diffhunk://#diff-46ee7a16ca0775fa522dc68f9ce7e0ac1d3f6b226262c5b0ee3efae56f63ee7aR425-R496) [[7]](diffhunk://#diff-f0b44e5cbb0d55d959e38da867daccf01767e23fbea1e61a67185dafdcf2b77fR592-R675) [[8]](diffhunk://#diff-f0b44e5cbb0d55d959e38da867daccf01767e23fbea1e61a67185dafdcf2b77fR25-R33) [[9]](diffhunk://#diff-f0b44e5cbb0d55d959e38da867daccf01767e23fbea1e61a67185dafdcf2b77fR48-R52) [[10]](diffhunk://#diff-d9490dca9c2cf34df53c3bd4d67c6716b40a01b3c7ea6933f20739112fc7af9bL184-R198) [[11]](diffhunk://#diff-a8d8ff648e3af852cc7e824c3c237fd2e4d9343e9608c84e814f9064a939e550R16-R23) [[12]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7R23) [[13]](diffhunk://#diff-07dceda09d3423b2de9d3469d0c23a2f2ebb6bfaa67fe3e3028766be01f478f7L51-R74) [[14]](diffhunk://#diff-fcd7bfd37a06441f4d72ea96ef3855fe918985305baa040f075a2603f4e3de71L16-R16) [[15]](diffhunk://#diff-f1d2ee1938a84dcb93f27fbe5e3a470075df87a0c5634edb4d725140e7b3970eL85-R85) [[16]](diffhunk://#diff-f1d2ee1938a84dcb93f27fbe5e3a470075df87a0c5634edb4d725140e7b3970eR102-R110)