### PR TITLE
UPDATED: contribution fees

### DIFF
--- a/src/modules/globals/system-settings/dto/settings-response.dto.ts
+++ b/src/modules/globals/system-settings/dto/settings-response.dto.ts
@@ -23,6 +23,11 @@ export class SystemSettingsResponseDto {
   protocol_flat_fee: number;
 
   @ApiProperty({
+    description: 'Protocol fee per asset entry (NFT or FT type, quantity ignored) in lovelace (2 ADA = 2000000)',
+  })
+  protocol_fee_per_asset: number;
+
+  @ApiProperty({
     description: 'LP recommended minimum liquidity in lovelace (500 ADA = 500000000)',
   })
   lp_recommended_min_liquidity: number;

--- a/src/modules/globals/system-settings/system-settings.service.ts
+++ b/src/modules/globals/system-settings/system-settings.service.ts
@@ -13,6 +13,8 @@ export interface SystemSettingsData {
   vlrm_creator_fee_enabled: boolean;
   protocol_contributors_fee: number;
   protocol_flat_fee: number;
+  // Per-asset contribution fee: charged per NFT or per FT type (quantity ignored)
+  protocol_fee_per_asset: number;
   lp_recommended_min_liquidity: number;
   max_acquire_amount_ada: number;
   auto_create_treasury_wallets: boolean;
@@ -51,6 +53,7 @@ const DEFAULT_SETTINGS: SystemSettingsData = {
   protocol_acquires_fee: 5000000,
   protocol_contributors_fee: 5000000,
   protocol_flat_fee: 5000000,
+  protocol_fee_per_asset: 2_000_000, // 2 ADA per asset entry (NFT or FT type, qty ignored)
   lp_recommended_min_liquidity: 500000000, // 500 ADA
   max_acquire_amount_ada: 10000000, // 10M ADA default limit
   auto_create_treasury_wallets: false, // Disabled by default for mainnet
@@ -162,6 +165,12 @@ export class SystemSettingsService implements OnModuleInit {
 
   get protocolFlatFee(): number {
     return this.settings.protocol_enabled ? this.settings.protocol_flat_fee : 0;
+  }
+
+  get protocolFeePerAsset(): number {
+    return this.settings.protocol_enabled
+      ? (this.settings.protocol_fee_per_asset ?? DEFAULT_SETTINGS.protocol_fee_per_asset)
+      : 0;
   }
 
   get lpRecommendedMinLiquidity(): number {

--- a/src/modules/vaults/dto/vault.response.ts
+++ b/src/modules/vaults/dto/vault.response.ts
@@ -287,26 +287,35 @@ export class VaultFullResponse extends VaultShortResponse {
   })
   projectedLpUsdAmount: number;
 
-  @ApiProperty({ description: 'Protocol fee for contributors in lovelace', required: false })
+  @ApiProperty({
+    description: 'Protocol fee per asset entry (NFT or FT type, quantity ignored) in lovelace',
+    required: false,
+  })
   @DtoRepresent({
     transform: false,
-    expose: { name: 'protocolContributorsFeeLovelace' },
+    expose: { name: 'protocolFeePerAssetLovelace' },
   })
-  protocolContributorsFeeLovelace?: number;
+  protocolFeePerAssetLovelace?: number;
 
-  @ApiProperty({ description: 'Protocol fee for contributors in ADA', required: false })
+  @ApiProperty({
+    description: 'Protocol fee per asset entry (NFT or FT type, quantity ignored) in ADA',
+    required: false,
+  })
   @DtoRepresent({
     transform: false,
-    expose: { name: 'protocolContributorsFeeAda' },
+    expose: { name: 'protocolFeePerAssetAda' },
   })
-  protocolContributorsFeeAda?: number;
+  protocolFeePerAssetAda?: number;
 
-  @ApiProperty({ description: 'Protocol fee for contributors in USD', required: false })
+  @ApiProperty({
+    description: 'Protocol fee per asset entry (NFT or FT type, quantity ignored) in USD',
+    required: false,
+  })
   @DtoRepresent({
     transform: false,
-    expose: { name: 'protocolContributorsFeeUsd' },
+    expose: { name: 'protocolFeePerAssetUsd' },
   })
-  protocolContributorsFeeUsd?: number;
+  protocolFeePerAssetUsd?: number;
 
   @ApiProperty({ description: 'Protocol fee for acquirers in lovelace', required: false })
   @DtoRepresent({

--- a/src/modules/vaults/phase-management/contribution/contribution-asset.utils.ts
+++ b/src/modules/vaults/phase-management/contribution/contribution-asset.utils.ts
@@ -1,0 +1,78 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { AssetType } from '@/types/asset.types';
+
+export const MAX_ASSET_DECIMALS = 20;
+export const DEFAULT_FT_DECIMALS = 6;
+
+export interface ContributionAssetLike {
+  type?: string;
+  quantity?: number;
+  decimals?: number;
+  metadata?: { decimals?: number };
+}
+
+/**
+ * Resolve and validate FT decimals from a contribution request.
+ * Rejects out-of-range values and mismatches between top-level and metadata fields.
+ */
+export function resolveFtDecimals(asset: ContributionAssetLike): number {
+  const fromAsset = asset.decimals;
+  const fromMetadata = asset.metadata?.decimals;
+
+  if (fromAsset !== undefined && fromMetadata !== undefined && Number(fromAsset) !== Number(fromMetadata)) {
+    throw new BadRequestException(
+      `Inconsistent decimals for fungible token: decimals=${fromAsset}, metadata.decimals=${fromMetadata}`
+    );
+  }
+
+  const raw = fromAsset ?? fromMetadata;
+  if (raw === undefined || raw === null) {
+    return DEFAULT_FT_DECIMALS;
+  }
+
+  const decimals = Number(raw);
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_ASSET_DECIMALS) {
+    throw new BadRequestException(
+      `Invalid decimals value "${raw}". Must be an integer between 0 and ${MAX_ASSET_DECIMALS}.`
+    );
+  }
+
+  return decimals;
+}
+
+/**
+ * Decimal-adjusted quantity used for vault capacity / policy limit checks.
+ * NFTs always count as 1; FT quantity is normalized using validated decimals.
+ */
+export function getContributionQuantityForLimits(asset: ContributionAssetLike): number {
+  if (asset.type === AssetType.NFT || asset.type === 'nft') {
+    return 1;
+  }
+
+  if (asset.type === AssetType.FT || asset.type === 'ft') {
+    const rawQuantity = Number(asset.quantity);
+    if (!Number.isFinite(rawQuantity) || rawQuantity <= 0) {
+      throw new BadRequestException('Fungible token contribution quantity must be greater than 0');
+    }
+
+    const decimals = resolveFtDecimals(asset);
+    return decimals > 0 ? rawQuantity / Math.pow(10, decimals) : rawQuantity;
+  }
+
+  return 1;
+}
+
+export function sumContributionQuantitiesForLimits(assets: ContributionAssetLike[]): number {
+  return assets.reduce((total, asset) => total + getContributionQuantityForLimits(asset), 0);
+}
+
+/** Persist validated decimals on FT assets so downstream limit checks use trusted values. */
+export function normalizeContributionAssets<T extends ContributionAssetLike>(assets: T[]): T[] {
+  return assets.map(asset => {
+    if (asset.type === AssetType.FT || asset.type === 'ft') {
+      return { ...asset, decimals: resolveFtDecimals(asset) };
+    }
+    return asset;
+  });
+}

--- a/src/modules/vaults/phase-management/contribution/contribution-fee.utils.ts
+++ b/src/modules/vaults/phase-management/contribution/contribution-fee.utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Protocol fee is charged per contributed asset entry (each NFT or each FT type).
+ * FT quantity is ignored — e.g. 500 L4VA_Fundable FT counts as 1 asset for fee.
+ */
+export function countAssetsForProtocolFee(assets: unknown[]): number {
+  return assets.length;
+}

--- a/src/modules/vaults/phase-management/contribution/contribution.service.ts
+++ b/src/modules/vaults/phase-management/contribution/contribution.service.ts
@@ -3,6 +3,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { ContributeReq } from './dto/contribute.req';
+import { countAssetsForProtocolFee } from './contribution-fee.utils';
+import {
+  getContributionQuantityForLimits,
+  normalizeContributionAssets,
+  sumContributionQuantitiesForLimits,
+} from './contribution-asset.utils';
 
 import { Asset } from '@/database/asset.entity';
 import { Proposal } from '@/database/proposal.entity';
@@ -54,7 +60,9 @@ export class ContributionService {
       );
     }
 
-    const assetsByPolicy = contributeReq.assets.reduce(
+    const normalizedAssets = normalizeContributionAssets(contributeReq.assets);
+
+    const assetsByPolicy = normalizedAssets.reduce(
       (acc, asset) => {
         if (!acc[asset.policyId]) {
           acc[asset.policyId] = [];
@@ -152,17 +160,7 @@ export class ContributionService {
       return this.handleExpansionContribution(vaultId, contributeReq, userId);
     }
 
-    // Calculate decimal-adjusted quantity for new contribution (to match currentAssetCount units)
-    const contributionAssetCount = contributeReq.assets.reduce((total, asset) => {
-      const rawQuantity = Number(asset.quantity) || 1;
-      if (asset.type === AssetType.FT) {
-        const decimals = asset.decimals ?? asset.metadata?.decimals ?? 6;
-        const decimalQuantity = decimals > 0 ? rawQuantity / Math.pow(10, decimals) : rawQuantity;
-        return total + decimalQuantity;
-      }
-      // NFTs always count as 1
-      return total + 1;
-    }, 0);
+    const contributionAssetCount = sumContributionQuantitiesForLimits(normalizedAssets);
 
     // Normal contribution flow - compare decimal-adjusted quantities
     if (currentAssetCount + contributionAssetCount > vaultData.max_contribute_assets) {
@@ -190,7 +188,7 @@ export class ContributionService {
       }
     }
 
-    if (contributeReq.assets.length > 0) {
+    if (normalizedAssets.length > 0) {
       const invalidAssets: string[] = [];
       const policyExceedsLimit: Array<{
         policyId: string;
@@ -209,16 +207,10 @@ export class ContributionService {
 
         const existingPolicyCount = policyCountMap.get(policyId) || 0;
         // Calculate decimal-adjusted quantity for this contribution
-        const policyAssetsQuantity = assetsByPolicy[policyId].reduce((total, asset) => {
-          const rawQuantity = Number(asset.quantity) || 1;
-          if (asset.type === AssetType.NFT) {
-            return total + 1;
-          }
-          // FT: convert raw to decimal
-          const decimals = asset.decimals ?? asset.metadata?.decimals ?? 6;
-          const decimalQuantity = decimals > 0 ? rawQuantity / Math.pow(10, decimals) : rawQuantity;
-          return total + decimalQuantity;
-        }, 0);
+        const policyAssetsQuantity = assetsByPolicy[policyId].reduce(
+          (total, asset) => total + getContributionQuantityForLimits(asset),
+          0
+        );
 
         // Additional safety check: prevent individual FT quantities from exceeding reasonable limits
         for (const asset of assetsByPolicy[policyId]) {
@@ -262,13 +254,16 @@ export class ContributionService {
       }
     }
 
+    const feeAssetCount = countAssetsForProtocolFee(normalizedAssets);
+    const contributionFee = Math.round(feeAssetCount * this.systemSettingsService.protocolFeePerAsset);
+
     const transaction = await this.transactionsService.createTransaction({
       vault_id: vaultId,
       type: TransactionType.contribute,
       assets: [],
       userId,
-      fee: this.systemSettingsService.protocolContributorsFee,
-      metadata: contributeReq.assets,
+      fee: contributionFee,
+      metadata: normalizedAssets,
     });
 
     return {
@@ -324,19 +319,10 @@ export class ContributionService {
       );
     }
 
-    // Calculate total asset count for this contribution
-    // FTs: convert raw quantity to decimal (e.g., 3,500,000 with 6 decimals = 3.5 tokens)
-    // NFTs: always count as 1
-    const contributionAssetCount = contributeReq.assets.reduce((total, asset) => {
-      const rawQuantity = Number(asset.quantity) || 1;
-      if (asset.type === AssetType.FT) {
-        const decimals = asset.decimals ?? asset.metadata?.decimals ?? 6;
-        const decimalQuantity = decimals > 0 ? rawQuantity / Math.pow(10, decimals) : rawQuantity;
-        return total + decimalQuantity;
-      }
-      // NFTs always count as 1
-      return total + 1;
-    }, 0);
+    const normalizedAssets = normalizeContributionAssets(contributeReq.assets);
+
+    // Calculate total asset count for vault limit checks (quantity-based for FTs)
+    const contributionAssetCount = sumContributionQuantitiesForLimits(normalizedAssets);
 
     // Check asset max if configured - count already CONFIRMED contributions
     if (!expansionConfig.noMax && expansionConfig.assetMax) {
@@ -383,14 +369,17 @@ export class ContributionService {
       );
     }
 
+    const feeAssetCount = countAssetsForProtocolFee(normalizedAssets);
+    const expansionFee = Math.round(feeAssetCount * this.systemSettingsService.protocolFeePerAsset);
+
     // Create transaction (claims will be created during expansion->locked transition)
     const transaction = await this.transactionsService.createTransaction({
       vault_id: vaultId,
       type: TransactionType.contribute,
       assets: [],
       userId,
-      fee: this.systemSettingsService.protocolContributorsFee,
-      metadata: contributeReq.assets,
+      fee: expansionFee,
+      metadata: normalizedAssets,
     });
 
     return {

--- a/src/modules/vaults/phase-management/contribution/dto/contribute.req.ts
+++ b/src/modules/vaults/phase-management/contribution/dto/contribute.req.ts
@@ -1,6 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose, Type, Transform } from 'class-transformer';
-import { IsArray, IsNotEmpty, IsOptional, ValidateNested, Min, Max, IsNumber } from 'class-validator';
+import { IsArray, IsNotEmpty, IsOptional, ValidateNested, Min, Max, IsNumber, IsInt } from 'class-validator';
+
+import { MAX_ASSET_DECIMALS } from '../contribution-asset.utils';
 
 import { AssetType } from '@/types/asset.types';
 
@@ -106,9 +108,14 @@ export class ContributionAsset {
   @ApiPropertyOptional({
     description: 'Number of decimals for fungible tokens',
     example: 0,
+    minimum: 0,
+    maximum: MAX_ASSET_DECIMALS,
   })
   @Expose()
   @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(MAX_ASSET_DECIMALS)
   decimals?: number;
 
   @ApiPropertyOptional({

--- a/src/modules/vaults/processing-tx/onchain/vault-contribution.service.ts
+++ b/src/modules/vaults/processing-tx/onchain/vault-contribution.service.ts
@@ -25,6 +25,7 @@ import { Proposal } from '@/database/proposal.entity';
 import { Transaction } from '@/database/transaction.entity';
 import { Vault } from '@/database/vault.entity';
 import { ContributionInput } from '@/modules/distribution/distribution.types';
+import { sumContributionQuantitiesForLimits } from '@/modules/vaults/phase-management/contribution/contribution-asset.utils';
 import { AssetStatus, AssetOriginType, AssetType } from '@/types/asset.types';
 import { ProposalStatus, ProposalType } from '@/types/proposal.types';
 import { TransactionStatus, TransactionType } from '@/types/transaction.types';
@@ -399,15 +400,7 @@ export class VaultContributionService {
       contributingAssets = (transaction.metadata as any).assets || [];
     }
 
-    // Count actual asset quantities: NFTs = 1 each, FTs = raw quantity converted to decimal
-    const contributingAssetCount = contributingAssets.reduce((sum, asset: any) => {
-      const rawQuantity = Number(asset?.quantity);
-      // For FTs, convert raw to decimal for counting
-      const decimals = asset.decimals ?? asset.metadata?.decimals ?? 6;
-      const decimalQuantity = decimals > 0 ? rawQuantity / Math.pow(10, decimals) : rawQuantity;
-      const assetCount = decimalQuantity && !Number.isNaN(decimalQuantity) ? decimalQuantity : 1;
-      return sum + assetCount;
-    }, 0);
+    const contributingAssetCount = sumContributionQuantitiesForLimits(contributingAssets);
 
     if (vault.vault_status === VaultStatus.expansion) {
       await this.validateExpansionLimits(transaction.id, transaction.vault_id, contributingAssetCount);

--- a/src/modules/vaults/vaults.service.ts
+++ b/src/modules/vaults/vaults.service.ts
@@ -1238,9 +1238,10 @@ export class VaultsService {
         : undefined,
       acquireExpansionNoMax,
       // Protocol fees
-      protocolContributorsFeeLovelace: this.systemSettingsService.protocolContributorsFee,
-      protocolContributorsFeeAda: this.systemSettingsService.protocolContributorsFee / 1_000_000,
-      protocolContributorsFeeUsd: (this.systemSettingsService.protocolContributorsFee / 1_000_000) * adaPrice,
+      // Per-asset rate: total fee = assetCount × protocolFeePerAssetLovelace
+      protocolFeePerAssetLovelace: this.systemSettingsService.protocolFeePerAsset,
+      protocolFeePerAssetAda: this.systemSettingsService.protocolFeePerAsset / 1_000_000,
+      protocolFeePerAssetUsd: (this.systemSettingsService.protocolFeePerAsset / 1_000_000) * adaPrice,
       protocolAcquiresFeeLovelace: this.systemSettingsService.protocolAcquiresFee,
       protocolAcquiresFeeAda: this.systemSettingsService.protocolAcquiresFee / 1_000_000,
       protocolAcquiresFeeUsd: (this.systemSettingsService.protocolAcquiresFee / 1_000_000) * adaPrice,


### PR DESCRIPTION
This pull request introduces a new protocol fee model that charges a fee per asset (NFT or FT unit) contributed, replacing the previous flat per-contributor fee. The changes update the system settings, DTOs, and service logic to support and expose this new per-asset fee, and ensure it is used throughout the contribution and vault logic.

**Protocol Fee Model Update**

- Added `protocol_fee_per_asset` to the system settings, including its TypeScript interface, DTO, and default value (2 ADA per asset). [[1]](diffhunk://#diff-fedf5a4441b2b76076bf856d462442c9f55e85eefa975264f049c2b0103eff21R16-R17) [[2]](diffhunk://#diff-fedf5a4441b2b76076bf856d462442c9f55e85eefa975264f049c2b0103eff21R56) [[3]](diffhunk://#diff-bafbc6ab4f89a1ec561937ae23c117eeb82c6e13c75ae0f10676295107ab9f86R25-R27)
- Introduced a getter for `protocolFeePerAsset` in `SystemSettingsService` for consistent access to the new setting.

**Fee Calculation and Application**

- Updated contribution and vault expansion logic to calculate the protocol fee as `contributionAssetCount * protocolFeePerAsset`, replacing the previous flat contributor fee. [[1]](diffhunk://#diff-64a6081150076f850966de91db78be6bca4a1b124490727ecccdd900c6734083R265-R272) [[2]](diffhunk://#diff-64a6081150076f850966de91db78be6bca4a1b124490727ecccdd900c6734083R388-R396)

**API and DTO Adjustments**

- Updated the `VaultFullResponse` DTO and related API properties to reflect the new per-asset fee fields in Lovelace, ADA, and USD, replacing the old contributor fee fields.
- Modified the `VaultsService` to expose the new per-asset fee fields in all relevant API responses, with correct currency conversions.