### PR TITLE
Remove commented out alert for asset price deviation review

### DIFF
--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -951,11 +951,11 @@ export class TaptoolsService {
         this.logger.warn(
           `${rejectedUpdates.length} asset price updates exceeded deviation threshold and were skipped for manual review`
         );
-        await this.alertsService.sendAlert('asset_price_deviation_batch_exceeded', {
-          totalRejected: rejectedUpdates.length,
-          rejectedAssets: rejectedUpdates,
-          action: 'price_updates_rejected_manual_review_required',
-        });
+        // await this.alertsService.sendAlert('asset_price_deviation_batch_exceeded', {
+        //   totalRejected: rejectedUpdates.length,
+        //   rejectedAssets: rejectedUpdates,
+        //   action: 'price_updates_rejected_manual_review_required',
+        // });
       }
 
       // Calculate and return TVL for all affected vaults


### PR DESCRIPTION
This pull request makes a minor change to the `TaptoolsService` by commenting out the alert notification for asset price deviations. The alert will no longer be sent when asset price updates exceed the deviation threshold and are skipped for manual review.

* The call to `alertsService.sendAlert` for the `'asset_price_deviation_batch_exceeded'` event is now commented out, so no alert will be sent when this condition occurs.