### PR TITLE
Refactor network configuration and remove debug logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,12 @@ services:
       REDIS_PORT: 6379
       PORT: 3000
     networks:
-      - l4va-network
+      l4va-network:
+        aliases:
+          - l4va-api
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/api/v1/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/v1/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -41,10 +43,12 @@ services:
       REDIS_PORT: 6379
       PORT: 3000
     networks:
-      - l4va-network
+      l4va-network:
+        aliases:
+          - l4va-api
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/api/v1/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/v1/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -708,9 +708,6 @@ export class TaptoolsService {
         if (tokenUnit === this.VLRM_TOKEN_UNIT) {
           const charli3Data = await this.charli3Client.getTokenCurrent(tokenUnit);
           tokenPriceAda = charli3Data?.current_price || null;
-          if (tokenPriceAda && tokenPriceAda > 0) {
-            this.logger.debug(`Using Charli3 price for VLRM: ${tokenPriceAda.toFixed(10)} ADA`);
-          }
         } else {
           tokenPriceAda = await this.dexHunterPricingService.getTokenPrice(tokenUnit);
         }
@@ -920,9 +917,6 @@ export class TaptoolsService {
                 if (tokenUnit === this.VLRM_TOKEN_UNIT) {
                   const charli3Data = await this.charli3Client.getTokenCurrent(tokenUnit);
                   tokenPriceAda = charli3Data?.current_price || null;
-                  if (tokenPriceAda && tokenPriceAda > 0) {
-                    this.logger.debug(`Using Charli3 price for VLRM: ${tokenPriceAda.toFixed(10)} ADA`);
-                  }
                 } else {
                   tokenPriceAda = await this.dexHunterPricingService.getTokenPrice(tokenUnit);
                 }
@@ -1875,9 +1869,6 @@ export class TaptoolsService {
         // Use Charli3 for VLRM
         const charli3Data = await this.charli3Client.getTokenCurrent(tokenBUnit);
         tokenBPrice = charli3Data?.current_price || 0;
-        if (tokenBPrice > 0) {
-          this.logger.debug(`Using Charli3 price for VLRM: ${tokenBPrice.toFixed(10)} ADA`);
-        }
       } else {
         tokenBPrice = (await this.dexHunterPricingService.getTokenPrice(tokenBUnit)) || 0;
       }
@@ -1887,9 +1878,6 @@ export class TaptoolsService {
         // Use Charli3 for VLRM
         const charli3Data = await this.charli3Client.getTokenCurrent(tokenAUnit);
         tokenAPrice = charli3Data?.current_price || 0;
-        if (tokenAPrice > 0) {
-          this.logger.debug(`Using Charli3 price for VLRM: ${tokenAPrice.toFixed(10)} ADA`);
-        }
       } else {
         tokenAPrice = (await this.dexHunterPricingService.getTokenPrice(tokenAUnit)) || 0;
       }
@@ -1957,9 +1945,6 @@ export class TaptoolsService {
         // Use Charli3 for VLRM
         const charli3Data = await this.charli3Client.getTokenCurrent(poolData.tokenA);
         tokenAPrice = charli3Data?.current_price || 0;
-        if (tokenAPrice > 0) {
-          this.logger.debug(`Using Charli3 price for VLRM: ${tokenAPrice.toFixed(10)} ADA`);
-        }
       } else {
         tokenAPrice = (await this.dexHunterPricingService.getTokenPrice(poolData.tokenA)) || 0;
       }
@@ -1970,9 +1955,6 @@ export class TaptoolsService {
         // Use Charli3 for VLRM
         const charli3Data = await this.charli3Client.getTokenCurrent(poolData.tokenB);
         tokenBPrice = charli3Data?.current_price || 0;
-        if (tokenBPrice > 0) {
-          this.logger.debug(`Using Charli3 price for VLRM: ${tokenBPrice.toFixed(10)} ADA`);
-        }
       } else {
         tokenBPrice = (await this.dexHunterPricingService.getTokenPrice(poolData.tokenB)) || 0;
       }


### PR DESCRIPTION
This pull request primarily removes debug logging statements related to Charli3 token pricing in the `TaptoolsService`, and updates the Docker Compose network configuration to add a network alias for the API service. The most important changes are grouped below:

**Logging Cleanup:**

* Removed debug log statements that output Charli3 price information for VLRM tokens in multiple locations within `taptools.service.ts`, resulting in cleaner logs and reduced verbosity. [[1]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L711-L713) [[2]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L923-L925) [[3]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L1878-L1880) [[4]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L1890-L1892) [[5]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L1960-L1962) [[6]](diffhunk://#diff-684d861f794e40a6bb663d3ff8031b3d066a323b6132651168f1af25bbfb8548L1973-L1975)

**Docker Compose Configuration:**

* Updated the `l4va-network` configuration in `docker-compose.yml` to add an alias `l4va-api` for the API service, improving network service discovery. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L20-R22) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L44-R48)