### PR TITLE
Enhance token price retrieval and improve OHLCV data logic

### DIFF
--- a/src/modules/dexhunter/dexhunter-pricing.client.ts
+++ b/src/modules/dexhunter/dexhunter-pricing.client.ts
@@ -342,7 +342,6 @@ export class DexHunterPricingClient {
     // Check cache first
     const cached = this.ohlcvCache.get<MarketOhlcvSeries>(cacheKey);
     if (cached !== undefined) {
-      this.logger.debug(`DexHunter OHLCV cache hit for ${tokenUnit.slice(0, 16)}... (${interval})`);
       return cached;
     }
 
@@ -360,8 +359,8 @@ export class DexHunterPricingClient {
         };
         from = to - numIntervals * (intervalSeconds[period] || 3600);
       } else {
-        // Default: get last 30 days
-        from = to - 30 * 24 * 60 * 60;
+        // Default: get last 365 days (all-time data)
+        from = to - 365 * 24 * 60 * 60;
       }
 
       const response = await fetch(`${this.dexHunterChartsUrl}/charts`, {

--- a/src/modules/dexhunter/dexhunter-pricing.client.ts
+++ b/src/modules/dexhunter/dexhunter-pricing.client.ts
@@ -149,7 +149,6 @@ export class DexHunterPricingClient {
       });
 
       await pipeline.exec();
-      this.logger.debug(`Bulk cached ${pricesMap.size} token prices in Redis`);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Redis batch set prices failed: ${errorMessage}`);

--- a/src/modules/market/market.service.ts
+++ b/src/modules/market/market.service.ts
@@ -71,10 +71,8 @@ export class MarketService implements OnModuleInit {
     let ohlcv = null;
 
     if (script_hash && asset_vault_name) {
-      // Try TapTools first (primary source)
       ohlcv = await this.tapToolsClient.getTokenOHLCV(script_hash, asset_vault_name, interval);
 
-      // Fallback to DexHunter if TapTools fails or returns null
       if (!ohlcv) {
         ohlcv = await this.dexHunterClient.getTokenOHLCV(script_hash, asset_vault_name, interval);
 

--- a/src/modules/taptools/taptools.controller.ts
+++ b/src/modules/taptools/taptools.controller.ts
@@ -45,4 +45,30 @@ export class TaptoolsController {
   async getTokenPools(@Param('tokenUnit') tokenUnit: string): Promise<TapToolsTokenPoolDto[]> {
     return this.taptoolsService.getTokenPools(tokenUnit);
   }
+
+  @Get('price/:tokenUnit')
+  @ApiDoc({
+    summary: 'Get token price in ADA',
+    description: 'Returns token price in ADA for a given token unit (includes VLRM -> Charli3 routing)',
+    status: 200,
+  })
+  @ApiParam({
+    name: 'tokenUnit',
+    description: 'Token unit (policyId + assetName in hex format)',
+    example: '63efb704b7396890e4d9539d030c0e667739043add65c00f96c586c056616c6f72756d',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Token price result in ADA',
+    schema: {
+      example: {
+        tokenUnit: '63efb704b7396890e4d9539d030c0e667739043add65c00f96c586c056616c6f72756d',
+        priceAda: 0.0184,
+      },
+    },
+  })
+  @UseGuards(AdminGuard)
+  async getTokenPrice(@Param('tokenUnit') tokenUnit: string): Promise<{ tokenUnit: string; priceAda: number | null }> {
+    return this.taptoolsService.getTokenPriceAda(tokenUnit);
+  }
 }

--- a/src/modules/taptools/taptools.service.ts
+++ b/src/modules/taptools/taptools.service.ts
@@ -56,6 +56,11 @@ interface AssetPriceResult {
   priceUsd: number;
 }
 
+interface TokenPriceResult {
+  tokenUnit: string;
+  priceAda: number | null;
+}
+
 @Injectable()
 export class TaptoolsService {
   private readonly logger = new Logger(TaptoolsService.name);
@@ -2434,5 +2439,44 @@ export class TaptoolsService {
    */
   public async getTokenPools(tokenUnit: string): Promise<TapToolsTokenPoolDto[]> {
     return this.tapToolsClient.getTokenPools(tokenUnit);
+  }
+
+  /**
+   * Get token price in ADA for a full token unit.
+   * Reuses existing FT pricing path (including VLRM -> Charli3).
+   */
+  public async getTokenPriceAda(tokenUnit: string): Promise<TokenPriceResult> {
+    if (!this.isMainnet) {
+      return { tokenUnit, priceAda: null };
+    }
+
+    // Cardano token unit = 56-char policyId + optional assetName (hex)
+    if (!tokenUnit || tokenUnit.length < 56) {
+      this.logger.warn(`Invalid token unit received for price lookup: ${tokenUnit}`);
+      return { tokenUnit, priceAda: null };
+    }
+
+    const policyId = tokenUnit.slice(0, 56);
+    const assetName = tokenUnit.slice(56);
+
+    try {
+      const { priceAda } = await this.getAssetValue({
+        policyId,
+        assetName,
+        isNFT: false,
+      });
+
+      return {
+        tokenUnit,
+        priceAda: priceAda > 0 ? priceAda : null,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Failed to resolve token price for ${tokenUnit.slice(0, 12)}...: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return { tokenUnit, priceAda: null };
+    }
   }
 }

--- a/src/modules/vaults/market-stats/vault-market-stats.service.ts
+++ b/src/modules/vaults/market-stats/vault-market-stats.service.ts
@@ -307,8 +307,6 @@ export class VaultMarketStatsService {
 
       if (data) {
         this.logger.log(`DexHunter OHLCV fallback successful for ${policyId}.${assetName}`);
-      } else {
-        this.logger.warn(`Both TapTools and DexHunter OHLCV unavailable for ${policyId}.${assetName}`);
       }
     }
 


### PR DESCRIPTION
This pull request introduces a new endpoint to retrieve a token's price in ADA via the TapTools service and makes several improvements and minor cleanups across the codebase. The most significant change is the addition of the `getTokenPriceAda` method and its corresponding API route, which enables clients to fetch token prices in ADA, including routing through VLRM -> Charli3. Additionally, some logging has been streamlined, and the default data range for DexHunter OHLCV data has been extended.

**New Token Price Endpoint:**

* Added a new GET endpoint `/price/:tokenUnit` to `TaptoolsController` that returns the price of a token in ADA, guarded by `AdminGuard` and documented via OpenAPI decorators.
* Implemented `getTokenPriceAda` in `TaptoolsService`, which validates the token unit, extracts policy ID and asset name, and reuses the existing asset valuation logic to return the ADA price or `null` if unavailable.
* Defined the `TokenPriceResult` interface for consistent return types from `getTokenPriceAda`.

**Logging and Data Range Improvements:**

* Changed the default OHLCV data range in `DexHunterPricingClient` from the last 30 days to the last 365 days (all-time data) for broader historical coverage.
* Removed redundant or verbose debug log messages in `DexHunterPricingClient` and `VaultMarketStatsService` to reduce log noise. [[1]](diffhunk://#diff-52b0fc53c85cd65118a9230d71cae3f24be3574a9cf24877a0e28db80b31ecb8L152) [[2]](diffhunk://#diff-52b0fc53c85cd65118a9230d71cae3f24be3574a9cf24877a0e28db80b31ecb8L345) [[3]](diffhunk://#diff-b1fbf0f0055071f1f1fe48f05f258dc6668d15aba1757312d339818ddf1fdcd6L310-L311)

**Minor Cleanups:**

* Removed unnecessary comments in `MarketService` related to the TapTools/DexHunter fallback logic.