### PR TITLE
Add pool and order validator addresses for LP rewards filtering

### DIFF
--- a/src/modules/taptools/interfaces/taptools.interface.ts
+++ b/src/modules/taptools/interfaces/taptools.interface.ts
@@ -15,4 +15,8 @@ export interface TapToolsTokenPoolDto {
   tokenBTicker: string;
   /** LP token total supply from Nexus/VyFi APIs (null if unavailable) */
   lpTotalSupply: number | null;
+  /** Pool validator address (VyFi only) - used to exclude from LP rewards */
+  poolValidatorAddress?: string;
+  /** Order validator address (VyFi only) - used to exclude from LP rewards */
+  orderValidatorAddress?: string;
 }

--- a/src/modules/taptools/taptools.client.ts
+++ b/src/modules/taptools/taptools.client.ts
@@ -274,6 +274,8 @@ export class TapToolsClient {
           const dex = pool.dex_name.toLowerCase();
           let lpTokenUnit = '';
           let lpTotalSupply: number | null = null;
+          let poolValidatorAddress: string | undefined = undefined;
+          let orderValidatorAddress: string | undefined = undefined;
 
           if (dex.includes('vyfi') && vyfiPools.length > 0) {
             // VyFi pools: use VyFi API (Nexus returns empty lpUnit)
@@ -281,6 +283,9 @@ export class TapToolsClient {
             if (match) {
               lpTokenUnit = this.extractVyFiLpTokenUnit(match);
               lpTotalSupply = match.lpQuantity ?? null;
+              // Extract validator addresses for LP rewards filtering
+              poolValidatorAddress = match.poolValidatorUtxoAddress;
+              orderValidatorAddress = match.orderValidatorUtxoAddress;
             }
           } else {
             // Other DEXs: use Nexus API
@@ -302,6 +307,8 @@ export class TapToolsClient {
             tokenBLocked: pool.token_1_amount, // already in ADA from DexHunter API
             tokenBTicker: 'ADA',
             lpTotalSupply,
+            poolValidatorAddress,
+            orderValidatorAddress,
           };
         })
       );


### PR DESCRIPTION
This pull request adds support for handling VyFi-specific validator addresses in the TapTools integration. These addresses are used to help exclude certain transactions from LP rewards calculations. The changes include updating the data transfer object and extracting the relevant addresses from the VyFi API response.

**VyFi validator address support:**

* Added optional `poolValidatorAddress` and `orderValidatorAddress` fields to the `TapToolsTokenPoolDto` interface for use with VyFi pools.
* Updated `TapToolsClient` to extract `poolValidatorUtxoAddress` and `orderValidatorUtxoAddress` from VyFi API responses and include them in the returned pool objects. [[1]](diffhunk://#diff-f960a22a988196417240918be84f09e6513c74908bc36000eae51bb356af82d1R277-R288) [[2]](diffhunk://#diff-f960a22a988196417240918be84f09e6513c74908bc36000eae51bb356af82d1R310-R311)